### PR TITLE
Linux ARM support

### DIFF
--- a/CoreHook.BinaryInjection/BinaryLoader/LinuxBinaryLoader.cs
+++ b/CoreHook.BinaryInjection/BinaryLoader/LinuxBinaryLoader.cs
@@ -20,10 +20,13 @@ namespace CoreHook.BinaryInjection
         private Dictionary<string, IntPtr> _cachedFunctions = new Dictionary<string, IntPtr>();
 
         private const string _libcName = "libc";
+        private const string _mallocName = "malloc";
 
         private const string _mailboxName = "RemoteThreadMailbox";
 
-        private const string _mallocName = "malloc";
+        private const string LinuxExecDotnetAssembly = "ExecuteDotnetAssembly";
+
+        private const string LinuxExecAssemblyFunction = "ExecuteManagedAssemblyClassFunction";
 
         private long _mailboxAddress;
 
@@ -144,8 +147,7 @@ namespace CoreHook.BinaryInjection
         {
             return GetCachedFunction(libName, function);
         }
-        private const string LinuxExecAssembly = "ExecuteDotnetAssembly";
-        private const string LinuxExecAssemblyFunction = "ExecuteManagedAssemblyClassFunction";
+
         public void CallFunctionWithRemoteArgs(Process process, string module, string function, IntPtr arguments)
         {
             if (IsAttached(process.Id))
@@ -244,7 +246,8 @@ namespace CoreHook.BinaryInjection
         {
             if (IsAttached(process.Id))
             {
-                var addr = GetFunctionAddress(module, function);            }
+                var addr = GetFunctionAddress(module, function);
+            }
         }
         private const string LinuxLoadAssembly = "LoadAssemblyBinaryArgs";
         public void ExecuteWithArgs(Process process, string module, object args)

--- a/CoreHook.BinaryInjection/BinaryLoader/LinuxBinaryLoader.cs
+++ b/CoreHook.BinaryInjection/BinaryLoader/LinuxBinaryLoader.cs
@@ -47,10 +47,7 @@ namespace CoreHook.BinaryInjection
 
             if (addr != IntPtr.Zero)
             {
-                //Thread.Sleep(1000);
-                Console.WriteLine($"Reading mailbox at {addr.ToInt64().ToString("X")}");
                 _mailboxAddress = ReadIntPtr(pid, addr.ToInt64());
-                Console.WriteLine($"Mailbox was at {_mailboxAddress.ToString("X")}");
             }
             else
             {
@@ -62,7 +59,6 @@ namespace CoreHook.BinaryInjection
             var addrSize = IntPtr.Size;
             var addrPtr = Marshal.AllocHGlobal(addrSize);
             Unmanaged.Linux.Process.ptrace_read(pid, new IntPtr(address), addrPtr, addrSize);
-
 
             byte[] managedArray = new byte[addrSize];
             Marshal.Copy(addrPtr, managedArray, 0, addrSize);
@@ -82,10 +78,7 @@ namespace CoreHook.BinaryInjection
         private static long ReadIntPtr(int pid, long address)
         {
             var addrSize = IntPtr.Size;
-            var addrPtr = Marshal.AllocHGlobal(addrSize);
-
-            Console.WriteLine($"ReadIntPtr address at {address.ToString("X")}," +
-                $"size: {addrSize}");            
+            var addrPtr = Marshal.AllocHGlobal(addrSize);       
 
             return PtraceReadPtr(pid, address);
         }
@@ -134,7 +127,6 @@ namespace CoreHook.BinaryInjection
             }
             else
             {
-                Console.WriteLine($"Searching for {libName}!{function}");
                 var addr = Unmanaged.Linux.Process.find_symbol(_symbolHandle, function, libName == _libcName ? null : libName);
                 if (addr != new IntPtr(-1))
                 {
@@ -163,8 +155,7 @@ namespace CoreHook.BinaryInjection
                 var argsBuf = Binary.StructToByteArray(args);
                 var bufPtr = CopyMemoryTo(process, argsBuf, (uint)argsBuf.Length);
 
-                //WriteRpcMsgArgs(pid, _mailboxAddress, args);
-                   SendRpcRequest(
+                SendRpcRequest(
                   pid,
                   _mailboxAddress,
                   new RemoteThreadArgs
@@ -211,11 +202,8 @@ namespace CoreHook.BinaryInjection
         private static void SendRpcRequest(int pid, long mailbox, object args, bool waitForRet = true)
         {
             var rpcArgs = Binary.StructToByteArray(args);
-            Console.WriteLine($"SendRpcRequest at {mailbox.ToString("X")}," +
-                $" length: {rpcArgs.Length}");
 
             PtraceWrite(pid, mailbox, rpcArgs, rpcArgs.Length);
-            Console.WriteLine($"SendRpcRequest WaitingForRet");
             if (waitForRet)
             {
                 WaitForRpc(pid, mailbox);
@@ -256,9 +244,7 @@ namespace CoreHook.BinaryInjection
         {
             if (IsAttached(process.Id))
             {
-                var addr = GetFunctionAddress(module, function);
-                Console.WriteLine($"{module}!{function} is at {addr.ToInt64()}");
-            }
+                var addr = GetFunctionAddress(module, function);            }
         }
         private const string LinuxLoadAssembly = "LoadAssemblyBinaryArgs";
         public void ExecuteWithArgs(Process process, string module, object args)
@@ -266,7 +252,6 @@ namespace CoreHook.BinaryInjection
             if (IsAttached(process.Id))
             {
                 var pid = process.Id;
-                //WriteRpcMsgArgs(pid, _mailboxAddress, args);
                 var argsBuf = Binary.StructToByteArray(args);
                 var bufPtr = CopyMemoryTo(process, argsBuf, (uint)argsBuf.Length);
  

--- a/CoreHook.CoreLoad/CoreHook.CoreLoad.csproj
+++ b/CoreHook.CoreLoad/CoreHook.CoreLoad.csproj
@@ -15,10 +15,12 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutputPath>..\Build\bin\Debug\netcoreapp2.0</OutputPath>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0-rc1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/CoreHook.Unmanaged/Linux/Process.cs
+++ b/CoreHook.Unmanaged/Linux/Process.cs
@@ -5,7 +5,7 @@ namespace CoreHook.Unmanaged.Linux
 {
     public static class Process
     {
-        internal const string LIBINJECT = "inject.so";
+        private const string LIBINJECT = "inject.so";
 
         [DllImport(LIBINJECT, SetLastError = true)]
         public static extern int injectByName(string targetName, string injectionLib, ref int pid);
@@ -17,10 +17,10 @@ namespace CoreHook.Unmanaged.Linux
         public static extern int injectByPid(int targetPid, string injectionLib);
 
         [DllImport(LIBINJECT, SetLastError = true)]
-        public static extern void ptrace_read(int targetPid, long addr, IntPtr vptr, int len);
-
+        public static extern void ptrace_read(int targetPid, IntPtr addr, IntPtr vptr, int len);
+    
         [DllImport(LIBINJECT, SetLastError = true)]
-        public static extern void ptrace_write(int targetPid, long addr, byte[] vptr, int len);
+        public static extern void ptrace_write(int targetPid, IntPtr addr, byte[] vptr, int len);
 
         [DllImport(LIBINJECT, SetLastError = true)]
         public static extern void ptrace_detach(int targetPid);

--- a/Examples/CoreHook.FileMonitor/CoreHook.FileMonitor.csproj
+++ b/Examples/CoreHook.FileMonitor/CoreHook.FileMonitor.csproj
@@ -9,6 +9,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\..\Build\bin\Debug\</OutputPath>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">


### PR DESCRIPTION
* Modify LinuxBinaryLoader class to support ARM process injection and .NET Core hosting by using the IntPtr type instead of a long for addresses