### PR TITLE
Use RemoteFunctionArgs struct to pass arguments to remote process

### DIFF
--- a/CoreHook.BinaryInjection/BinaryLoader/BinaryLoader.cs
+++ b/CoreHook.BinaryInjection/BinaryLoader/BinaryLoader.cs
@@ -40,7 +40,10 @@ namespace CoreHook.BinaryInjection
         {
             LoadAssemblyWithArgs(process, module, new FunctionCallArgs(function, arguments));
         }
-
+        public void CallFunctionWithRemoteArgs(Process process, string module, string function, RemoteFunctionArgs arguments)
+        {
+            LoadAssemblyWithArgs(process, module, new FunctionCallArgs(function, arguments));
+        }
         public void CallFunctionWithRemoteArgs(Process process, string module, string function, IntPtr arguments)
         {
             LoadAssemblyWithArgs(process, module, new FunctionCallArgs(function, arguments));

--- a/CoreHook.BinaryInjection/BinaryLoader/IBinaryLoader.cs
+++ b/CoreHook.BinaryInjection/BinaryLoader/IBinaryLoader.cs
@@ -8,6 +8,7 @@ namespace CoreHook.BinaryInjection
     {
         void Load(Process targetProcess, string binaryPath, IEnumerable<string> dependencies = null, string dir = null);
         void ExecuteWithArgs(Process process, string module, object args);
+        void CallFunctionWithRemoteArgs(Process process, string module, string function, RemoteFunctionArgs arguments);
         void CallFunctionWithRemoteArgs(Process process, string module, string function, IntPtr arguments);
         IntPtr CopyMemoryTo(Process proc, byte[] buffer, uint length);
     }

--- a/CoreHook.BinaryInjection/BinaryLoader/LinuxBinaryLoader.cs
+++ b/CoreHook.BinaryInjection/BinaryLoader/LinuxBinaryLoader.cs
@@ -176,6 +176,35 @@ namespace CoreHook.BinaryInjection
             }
         }
 
+
+        public void CallFunctionWithRemoteArgs(Process process, string module, string function, RemoteFunctionArgs arguments)
+        {
+            if (IsAttached(process.Id))
+            {
+                var pid = process.Id;
+                var args = new LinuxFunctionCallArgs(function, arguments);
+                var argsBuf = Binary.StructToByteArray(args);
+                var bufPtr = CopyMemoryTo(process, argsBuf, (uint)argsBuf.Length);
+
+                SendRpcRequest(
+                  pid,
+                  _mailboxAddress,
+                  new RemoteThreadArgs
+                  {
+                      Status = 1,
+                      ProcFlags = 0,
+                      Result = 0,
+                      ThreadAttributes = 0,
+                      CreationFlags = 1,
+                      StackSize = 0,
+                      StartAddress = GetCachedFunction(module, LinuxExecAssemblyFunction),
+                      Params = bufPtr
+                  },
+                  false
+                );
+            }
+        }
+
         public IntPtr CopyMemoryTo(Process proc, byte[] buffer, uint length)
         {
             var id = proc.Id;

--- a/CoreHook.BinaryInjection/BinaryLoader/MacOSBinaryLoader.cs
+++ b/CoreHook.BinaryInjection/BinaryLoader/MacOSBinaryLoader.cs
@@ -27,6 +27,21 @@ namespace CoreHook.BinaryInjection
             Unmanaged.MacOS.Process.injectByPidWithArgs(process.Id, parameters, parameters.Length);
         }
 
+        public void CallFunctionWithRemoteArgs(Process process, string module, string function, RemoteFunctionArgs arguments)
+        {
+            // combinary functioncallargs and binaryloader args
+            var paramArgs = new DotnetAssemblyFunctionCall()
+            {
+                coreRunLib = System.Text.Encoding.ASCII.GetBytes(_coreRunLib.PadRight(1024, '\0')),
+                binaryLoaderFunctionName = System.Text.Encoding.ASCII.GetBytes(LoadAssemblyBinaryArgsFuncName.PadRight(256, '\0')),
+                assemblyCallFunctionName = System.Text.Encoding.ASCII.GetBytes(ExecManagedAssemblyClassFunctionName.PadRight(256, '\0')),
+                binaryLoaderArgs = (MacOSBinaryLoaderArgs)_binaryLoaderArgs,
+                assemblyFunctionCall = new LinuxFunctionCallArgs(function, arguments)
+            };
+            byte[] parameters = Binary.StructToByteArray(paramArgs);
+            Unmanaged.MacOS.Process.injectByPidWithArgs(process.Id, parameters, parameters.Length);
+        }
+
         public IntPtr CopyMemoryTo(Process proc, byte[] buffer, uint length)
         {
             return Unmanaged.MacOS.Process.copyMemToProcessByPid(proc.Id, buffer, length);

--- a/CoreHook.BinaryInjection/BinaryLoader/MacOSBinaryLoaderArgs.cs
+++ b/CoreHook.BinaryInjection/BinaryLoader/MacOSBinaryLoaderArgs.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
+﻿using System.Runtime.InteropServices;
 
 namespace CoreHook.BinaryInjection
 {
     [StructLayout(LayoutKind.Sequential)]
     public struct DotnetAssemblyFunctionCall
     {
-       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1024)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1024)]
         public byte[] coreRunLib;
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 256)]
         public byte[] binaryLoaderFunctionName;

--- a/CoreHook.BinaryInjection/Host/FunctionCallArgs.cs
+++ b/CoreHook.BinaryInjection/Host/FunctionCallArgs.cs
@@ -68,6 +68,28 @@ namespace CoreHook.BinaryInjection
             Function = Encoding.Unicode.GetBytes(function.PadRight(256, '\0'));
             Arguments = Binary.StructToByteArray(arguments, 512);
         }
+
+        public FunctionCallArgs(string classFunctionName, RemoteFunctionArgs arguments)
+        {
+            var args = classFunctionName.Split('.');
+            string assembly = "";
+            var argsCount = args.Length - 2;
+            for (var x = 0; x < argsCount; x++)
+            {
+                assembly += args[x];
+                if (x != argsCount - 1)
+                {
+                    assembly += ".";
+                }
+            }
+            var type = args[argsCount++];
+            var function = args[argsCount];
+
+            Assembly = Encoding.Unicode.GetBytes(assembly.PadRight(256, '\0'));
+            Class = Encoding.Unicode.GetBytes(string.Format("{0}.{1}", assembly, type).PadRight(256, '\0'));
+            Function = Encoding.Unicode.GetBytes(function.PadRight(256, '\0'));
+            Arguments = Binary.StructToByteArray(arguments, 512);
+        }
         public FunctionCallArgs(string assembly, string type, string function, byte[] arguments)
         {
             Assembly = Encoding.Unicode.GetBytes(assembly.PadRight(256, '\0'));

--- a/CoreHook.BinaryInjection/Host/LinuxFunctionCallArgs.cs
+++ b/CoreHook.BinaryInjection/Host/LinuxFunctionCallArgs.cs
@@ -46,5 +46,26 @@ namespace CoreHook.BinaryInjection
             Function = Encoding.ASCII.GetBytes(function.PadRight(256, '\0'));
             Arguments = Binary.StructToByteArray(arguments, 512);
         }
+        public LinuxFunctionCallArgs(string classFunctionName, RemoteFunctionArgs arguments)
+        {
+            var args = classFunctionName.Split('.');
+            string assembly = "";
+            var argsCount = args.Length - 2;
+            for (var x = 0; x < argsCount; x++)
+            {
+                assembly += args[x];
+                if (x != argsCount - 1)
+                {
+                    assembly += ".";
+                }
+            }
+            var type = args[argsCount++];
+            var function = args[argsCount];
+
+            Assembly = Encoding.ASCII.GetBytes(assembly.PadRight(256, '\0'));
+            Class = Encoding.ASCII.GetBytes(string.Format("{0}.{1}", assembly, type).PadRight(256, '\0'));
+            Function = Encoding.ASCII.GetBytes(function.PadRight(256, '\0'));
+            Arguments = Binary.StructToByteArray(arguments, 512);
+        }
     }
 }

--- a/CoreHook.BinaryInjection/Host/RemoteFunctionArgs.cs
+++ b/CoreHook.BinaryInjection/Host/RemoteFunctionArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace CoreHook.BinaryInjection
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RemoteFunctionArgs
+    {
+        public IntPtr UserData;
+        public uint UserDataSize;
+    }
+}

--- a/CoreHook.ManagedHook/Remote/RemoteHooking.cs
+++ b/CoreHook.ManagedHook/Remote/RemoteHooking.cs
@@ -312,7 +312,11 @@ namespace CoreHook.ManagedHook.Remote
                         binaryLoader.CallFunctionWithRemoteArgs(proc,
                             coreRunDll,
                             CoreHookLoaderMethodName,
-                            argsAddr);
+                            new RemoteFunctionArgs()
+                            {
+                                UserData = argsAddr,
+                                UserDataSize = length
+                            });
                     }
                 }
                 finally


### PR DESCRIPTION
* Use a structure to pass arguments to remote .NET assembly function class instead of a pointer
* Allows us to easily specify the size of the arguments and any other information we want to add