### PR TITLE
Switch from EasyHook to Corehook native dll

### DIFF
--- a/CoreHook.BinaryInjection/BinaryLoader/LinuxBinaryLoader.cs
+++ b/CoreHook.BinaryInjection/BinaryLoader/LinuxBinaryLoader.cs
@@ -80,9 +80,6 @@ namespace CoreHook.BinaryInjection
         }
         private static long ReadIntPtr(int pid, long address)
         {
-            var addrSize = IntPtr.Size;
-            var addrPtr = Marshal.AllocHGlobal(addrSize);       
-
             return PtraceReadPtr(pid, address);
         }
         private void PtraceAttach(int pid)

--- a/CoreHook/DllImport.cs
+++ b/CoreHook/DllImport.cs
@@ -7,7 +7,7 @@ namespace CoreHook
 {
     static class NativeAPI_x86
     {
-        private const String DllName = "EasyHook32.dll";
+        private const String DllName = "corehook32.dll";
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public static extern String RtlGetLastErrorStringCopy();
@@ -200,7 +200,7 @@ namespace CoreHook
 
     static class NativeAPI_x64
     {
-        private const String DllName = "EasyHook64.dll";
+        private const String DllName = "corehook64.dll";
 
         internal static ILibLoader libLoader;
         internal static IntPtr libHandle;
@@ -209,7 +209,7 @@ namespace CoreHook
             _hookingLibMaps = new Dictionary<OSPlatform, Tuple<ILibLoader, string>>()
         {
             {
-                OSPlatform.Windows, new Tuple<ILibLoader, string>(new LibLoaderWindows(), "EasyHook64.dll")
+                OSPlatform.Windows, new Tuple<ILibLoader, string>(new LibLoaderWindows(), "corehook64.dll")
             },
             {
                 OSPlatform.Linux, new Tuple<ILibLoader, string>(new LibLoaderUnix(), "libcorehook.so")
@@ -537,13 +537,17 @@ namespace CoreHook
         public const Int32 STATUS_WOW_ASSERTION = unchecked((Int32)0xC0009898L);
         public const Int32 STATUS_ACCESS_DENIED = unchecked((Int32)0xC0000022L);
 
-        internal static T LoadFunction<T>(string name, ILibLoader loader, IntPtr handle) where T : class
+        private static T LoadFunction<T>(string name, ILibLoader loader, IntPtr handle) where T : class
         {
             IntPtr address = loader.GetProcAddress(handle, name);
             var function = Marshal.GetDelegateForFunctionPointer(address, typeof(T));
             return function as T;
         }
-
+        private static bool IsArchitectureArm()
+        {
+            var arch = RuntimeInformation.ProcessArchitecture;
+            return arch == Architecture.Arm || arch == Architecture.Arm64;
+        }
         private static String ComposeString()
         {
             return String.Format("{0} (Code: {1})", RtlGetLastErrorString(), RtlGetLastError());
@@ -625,7 +629,7 @@ namespace CoreHook
                     NativeAPI_x64.libHandle);
                 Force(LhInstallHook(InEntryPoint, InHookProc, InCallback, OutHandle));
             }
-            else Force(NativeAPI_x86.LhInstallHook(InEntryPoint, InHookProc, InCallback, OutHandle));
+            else Force(NativeAPI_x86.LhInstallHook(InEntryPoint, InHookProc, InCallback, OutHandle));            
         }
 
         public static void LhUninstallHook(IntPtr RefHandle)

--- a/Examples/UWP/CoreHook.UWP.FileMonitor/Program.cs
+++ b/Examples/UWP/CoreHook.UWP.FileMonitor/Program.cs
@@ -28,7 +28,7 @@ namespace CoreHook.UWP.FileMonitor
             ParameterValueConverter = new CamelCaseJsonValueConverter()
         };
 
-        const string CoreHookPipeName = "CoreHook";
+        private const string CoreHookPipeName = "CoreHook";
 
         static void Main(string[] args)
         {
@@ -73,8 +73,8 @@ namespace CoreHook.UWP.FileMonitor
                 return;
             }
 
-            string easyHookDll = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-                Environment.Is64BitProcess ? "EasyHook64.dll" : "EasyHook32.dll");
+            string coreHookDll = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                Environment.Is64BitProcess ? "corehook64.dll" : "corehook32.dll");
 
             GrantAllAppPkgsAccessToDir(currentDir);
             GrantAllAppPkgsAccessToDir(Path.Combine(currentDir, "netstandard2.0"));
@@ -86,17 +86,17 @@ namespace CoreHook.UWP.FileMonitor
             }
 
             // inject FileMon dll into process
-            InjectDllIntoTarget(TargetPID, injectionLibrary, easyHookDll);
+            InjectDllIntoTarget(TargetPID, injectionLibrary, coreHookDll);
 
             // start RPC server
             StartListener();
 
         }
-        static void InjectDllIntoTarget(int procId, string injectionLibrary, string easyHookDll)
+        static void InjectDllIntoTarget(int procId, string injectionLibrary, string coreHookDll)
         {          
-            if (!File.Exists(easyHookDll))
+            if (!File.Exists(coreHookDll))
             {
-                Console.WriteLine("Cannot find EasyHook dll");
+                Console.WriteLine("Cannot find corehook dll");
                 return;
             }
 
@@ -110,7 +110,7 @@ namespace CoreHook.UWP.FileMonitor
             // path to CoreRunDLL.dll
             var coreRunDll = Path.Combine(currentDir,
                 Environment.Is64BitProcess ? "CoreRunDLL64.dll" : "CoreRunDLL32.dll");
-            if (!File.Exists(easyHookDll))
+            if (!File.Exists(coreRunDll))
             {
                 coreRunDll = Environment.GetEnvironmentVariable("CORERUNDLL");
                 if (!File.Exists(coreRunDll))
@@ -128,10 +128,9 @@ namespace CoreHook.UWP.FileMonitor
                 return;
             }
 
-            // for now, we use the EasyHook dll to support function hooking on Windows
             ManagedHook.Remote.RemoteHooking.Inject(
                 procId,
-                easyHookDll);
+                coreHookDll);
 
             ManagedHook.Remote.RemoteHooking.Inject(
                 procId,

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Inspired and based on the great [EasyHook](https://github.com/EasyHook/EasyHook)
 ## Dependencies
 
 * [.NET Core](https://docs.microsoft.com/en-us/dotnet/core/)
+* [CoreHook.Hooking](https://github.com/unknownv2/CoreHook.Hooking)
 * [CoreHook.Host](https://github.com/unknownv2/CoreHook.Host)
 * [CoreHook.ProcessInjection](https://github.com/unknownv2/CoreHook.ProcessInjection)
 * [CoreHook.UnixHook](https://github.com/unknownv2/CoreHook.UnixHook)
-* [EasyHook](https://github.com/EasyHook/EasyHook)
 * [JsonRpc (For Examples Only)](https://github.com/CXuesong/JsonRpc.Standard) 
 
 


### PR DESCRIPTION
* Switch native dll dependency from EasyHook to the CoreHook.Hooking repository for Windows