### PR TITLE
Change .NET Core loading paths

### DIFF
--- a/CoreHook.ManagedHook/Remote/RemoteHooking.cs
+++ b/CoreHook.ManagedHook/Remote/RemoteHooking.cs
@@ -57,7 +57,7 @@ namespace CoreHook.ManagedHook.Remote
         }
   
         public static void CreateAndInject(
-            string InEXEPath,
+            string exePath,
             string coreHookDll,
             string coreRunDll,
             string coreLoadDll,
@@ -76,7 +76,7 @@ namespace CoreHook.ManagedHook.Remote
             var si = new NativeMethods.StartupInfo();
             var pi = new NativeMethods.ProcessInformation();
 
-            if(Unmanaged.Windows.NativeAPI.DetourCreateProcessWithDllExW(InEXEPath,
+            if(Unmanaged.Windows.NativeAPI.DetourCreateProcessWithDllExW(exePath,
                 InCommandLine,
                 IntPtr.Zero,
                 IntPtr.Zero,
@@ -113,7 +113,7 @@ namespace CoreHook.ManagedHook.Remote
             }
             else
             {
-                throw new ProcessStartException(InEXEPath);
+                throw new ProcessStartException(exePath);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Inspired and based on the great [EasyHook](https://github.com/EasyHook/EasyHook)
 
 ### Windows
 
-First, set the  environment variables `CORE_LIBRARIES` and `CORE_ROOT` to the installation folder of your desired dotnet runtime. For example, the default installation folder for the .NET Core 2.1 runtime is at `C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.0 (x64)` and `C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App\2.1.0 (x86)`. So you set both `CORE_LIBRARIES` and `CORE_ROOT` to *one* of those folders based on the architecture of the program you are targeting. 
+First, set the environment variables `CORE_LIBRARIES_32` and `CORE_ROOT_32` to the installation folder of your desired dotnet runtime. For example, the default installation folder for the .NET Core 2.1 runtime is at `C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.0 (for x64)` and `C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App\2.1.0 (for x86)`. So you set both `CORE_LIBRARIES_32` and `CORE_ROOT_32` to `C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App\2.1.0`. Then set both `CORE_LIBRARIES_64` and `CORE_ROOT_64` to `C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.0`.
 
 Then open the `CoreHook` solution `(.sln file)` in Visual Studio and you can build examples, either `CoreHook.FileMonitor` or `CoreHook.UWP.FileMonitor`.
 


### PR DESCRIPTION
* Switch Windows Environment variables from one set of CORE_ROOT and CORE_LIBRARIES to CORE_ROOT_32, CORE_LIBRARIES_32, CORE_ROOT_64, CORE_LIBRARIES_64 to handle loading x86 and x64 applications
