### PR TITLE
Update binary function finding

### DIFF
--- a/CoreHook.DependencyModel/AssemblyResolver.cs
+++ b/CoreHook.DependencyModel/AssemblyResolver.cs
@@ -29,7 +29,7 @@ namespace CoreHook.DependencyModel
                 {
                     new Resolution.AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(path)),
                     new Resolution.PackageCompilationAssemblyResolver(),
-                     new ReferenceAssemblyPathResolver()
+                    new ReferenceAssemblyPathResolver()
                 });
 
                 loadContext = AssemblyLoadContext.GetLoadContext(Assembly);

--- a/CoreHook.DependencyModel/CoreHook.DependencyModel.csproj
+++ b/CoreHook.DependencyModel/CoreHook.DependencyModel.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 

--- a/CoreHook/CoreHook.csproj
+++ b/CoreHook/CoreHook.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,7 +6,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\Build\bin\Debug\netcoreapp2.0\</OutputPath>
+    <OutputPath>..\Build\bin\Debug\netcoreapp2.1\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
 </Project>

--- a/CoreHook/LocalHook.cs
+++ b/CoreHook/LocalHook.cs
@@ -798,15 +798,20 @@ namespace CoreHook
             String InModule,
             String InSymbolName)
         {
-            IntPtr Module = NativeAPI.GetModuleHandle(InModule);
+            if(InModule == null)
+            {
+                throw new ArgumentNullException(InModule);
+            }
+            if (InSymbolName == null)
+            {
+                throw new ArgumentNullException(InModule);
+            }
 
-            if (Module == IntPtr.Zero)
-                throw new DllNotFoundException("The given library is not loaded into the current process.");
-
-            IntPtr Method = NativeAPI.GetProcAddress(Module, InSymbolName);
-
+            IntPtr Method = NativeAPI.DetourFindFunction(InModule, InSymbolName);
             if (Method == IntPtr.Zero)
+            {
                 throw new MissingMethodException("The given method does not exist.");
+            }
 
             return Method;
         }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A library to intercept function calls in applications and extend their functiona
 
 Inspired and based on the great [EasyHook](https://github.com/EasyHook/EasyHook).
 
+**The library is still in development and a lot might be broken. Pull requests/contributions are all welcome!**
+
 ## Dependencies
 
 * [.NET Core](https://docs.microsoft.com/en-us/dotnet/core/)
@@ -86,4 +88,29 @@ You can then start the `CoreHook.FileMonitor.exe` program on your ARM device.
 
  There is currently no way to set the proper access control on our pipes on the .NET Core platform and the issue is [being tracked here](https://github.com/dotnet/corefx/issues/30170) so we use PInvoke to call `kernel32.dll!CreateNamedPipe` directly.
 
-**The library is still in development and a lot might be broken. Pull requests/contributions are all welcome!**
+
+## Original Licenses
+
+### [EasyHook](https://github.com/EasyHook/EasyHook)
+
+```
+Copyright (c) 2009 Christoph Husse & Copyright (c) 2012 Justin Stenning
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```


### PR DESCRIPTION
* Switch to using DetourFindFunction for getting function addresses to allow hooking functions that aren't exports using symbols
* Set CoreHook project to output to proper directory (netcoreapp2.1)
* Breaks compability with old EasyHook native dlls