### PR TITLE
Refractor system types

### DIFF
--- a/CoreHook.CoreLoad/AllowAllAssemblyVersionsDeserializationBinder.cs
+++ b/CoreHook.CoreLoad/AllowAllAssemblyVersionsDeserializationBinder.cs
@@ -32,7 +32,7 @@ namespace CoreHook.CoreLoad
             try
             {
                 // 1. First try to bind without overriding assembly
-                typeToDeserialize = Type.GetType(String.Format("{0}, {1}", typeName, assemblyName));
+                typeToDeserialize = Type.GetType(string.Format("{0}, {1}", typeName, assemblyName));
             }
             catch
             {

--- a/CoreHook.CoreLoad/ConnectionData.cs
+++ b/CoreHook.CoreLoad/ConnectionData.cs
@@ -14,7 +14,7 @@ namespace CoreHook.CoreLoad
         {
             Invalid = 0,
             NoChannel = 1,
-            Valid = Int32.MaxValue
+            Valid = int.MaxValue
         }
 
         private RemoteEntryInfo _unmanagedInfo;

--- a/CoreHook.CoreLoad/ManagedRemoteInfo.cs
+++ b/CoreHook.CoreLoad/ManagedRemoteInfo.cs
@@ -10,6 +10,5 @@ namespace CoreHook.CoreLoad
         public string UserLibrary;
         public string UserLibraryName;
         public int HostPID;
-        public bool RequireStrongName;
     }
 }

--- a/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
+++ b/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
@@ -71,7 +71,7 @@ namespace CoreHook.IPC.NamedPipes
             }
             catch (Exception e)
             {
-                LogErrorAndExit("OpenListeningPipe caught unhandled exception", e);
+                LogError("OpenListeningPipe caught unhandled exception", e);
             }
         }
 
@@ -103,7 +103,6 @@ namespace CoreHook.IPC.NamedPipes
                 catch (IOException e)
                 {
                     connectionBroken = true;
-                    LogErrorAndExit("OnNewConnection caught IOException", e);
                 }
                 catch (ObjectDisposedException)
                 {
@@ -114,7 +113,7 @@ namespace CoreHook.IPC.NamedPipes
                 }
                 catch (Exception e)
                 {
-                    LogErrorAndExit("OnNewConnection caught unhandled exception", e);
+                    LogError("OnNewConnection caught unhandled exception", e);
                 }
                 if (!isStopping)
                 {
@@ -127,7 +126,7 @@ namespace CoreHook.IPC.NamedPipes
                         }
                         catch (Exception e)
                         {
-                            LogErrorAndExit("Unhandled exception in connection handler", e);
+                            LogError("Unhandled exception in connection handler", e);
                         }
                     }
                 }
@@ -138,7 +137,7 @@ namespace CoreHook.IPC.NamedPipes
             }
         }
 
-        private void LogErrorAndExit(string message, Exception e)
+        private void LogError(string message, Exception e)
         {
             Console.WriteLine(message);
             Console.WriteLine(e);

--- a/CoreHook.ManagedHook/Remote/RemoteHooking.cs
+++ b/CoreHook.ManagedHook/Remote/RemoteHooking.cs
@@ -235,11 +235,11 @@ namespace CoreHook.ManagedHook.Remote
 
         private static GCHandle PrepareInjection(
             ManagedRemoteInfo remoteInfo,
-            ref String libraryX86,
-            ref String libraryX64,
+            ref string libraryX86,
+            ref string libraryX64,
             MemoryStream argsStream)
         {
-            if (String.IsNullOrEmpty(libraryX86) && String.IsNullOrEmpty(libraryX64))
+            if (string.IsNullOrEmpty(libraryX86) && string.IsNullOrEmpty(libraryX64))
                 throw new ArgumentException("At least one library for x86 or x64 must be provided");
 
             // ensure full path information in case of file names...
@@ -262,7 +262,7 @@ namespace CoreHook.ManagedHook.Remote
             }
             else
             {
-                throw new FileNotFoundException(String.Format("The given assembly could not be found. {0}", remoteInfo.UserLibrary), remoteInfo.UserLibrary);
+                throw new FileNotFoundException(string.Format("The given assembly could not be found. {0}", remoteInfo.UserLibrary), remoteInfo.UserLibrary);
             }
 
             remoteInfo.ChannelName = InjectionPipe;

--- a/CoreHook.Unmanaged/Windows/Process.cs
+++ b/CoreHook.Unmanaged/Windows/Process.cs
@@ -1,55 +1,53 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace CoreHook.Unmanaged.Windows
 {
     static class NativeAPI_x86
     {
-        private const String DllName = "corehook32.dll";
+        private const string DllName = "corehook32.dll";
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean DetourCreateProcessWithDllExW(
-            [MarshalAs(UnmanagedType.LPWStr)]String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllExW(
+            [MarshalAs(UnmanagedType.LPWStr)]string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessW);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean DetourCreateProcessWithDllExA(
-            String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllExA(
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessA);
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean DetourCreateProcessWithDllsExW(
-            String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllsExW(
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
             uint nDlls,
@@ -57,15 +55,15 @@ namespace CoreHook.Unmanaged.Windows
             IntPtr pfCreateProcessW);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean DetourCreateProcessWithDllsExA(
-            String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllsExA(
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
             uint nDlls,
@@ -75,48 +73,48 @@ namespace CoreHook.Unmanaged.Windows
 
     static class NativeAPI_x64
     {
-        private const String DllName = "corehook64.dll";
+        private const string DllName = "corehook64.dll";
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean DetourCreateProcessWithDllExW(
-            [MarshalAs(UnmanagedType.LPWStr)]String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllExW(
+            [MarshalAs(UnmanagedType.LPWStr)]string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessW);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean DetourCreateProcessWithDllExA(
-            String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllExA(
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessA);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean DetourCreateProcessWithDllsExW(
-              [MarshalAs(UnmanagedType.LPWStr)]String lpApplicationName,
-              String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllsExW(
+              [MarshalAs(UnmanagedType.LPWStr)]string lpApplicationName,
+              string lpCommandLine,
               IntPtr lpProcessAttributes,
               IntPtr lpThreadAttributes,
               bool bInheritHandles,
               uint dwCreationFlags,
               IntPtr lpEnvironment,
-              String lpCurrentDirectory,
+              string lpCurrentDirectory,
               ref NativeMethods.StartupInfo lpStartupInfo,
               out NativeMethods.ProcessInformation lpProcessInformation,
               uint nDlls,
@@ -124,15 +122,15 @@ namespace CoreHook.Unmanaged.Windows
               IntPtr pfCreateProcessW);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean DetourCreateProcessWithDllsExA(
-            String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllsExA(
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
             uint nDlls,
@@ -142,9 +140,9 @@ namespace CoreHook.Unmanaged.Windows
 
     public static class NativeAPI
     {
-        public const Int32 MAX_HOOK_COUNT = 1024;
-        public const Int32 MAX_ACE_COUNT = 128;
-        public readonly static Boolean Is64Bit = IntPtr.Size == 8;
+        public const int MAX_HOOK_COUNT = 1024;
+        public const int MAX_ACE_COUNT = 128;
+        public readonly static bool Is64Bit = IntPtr.Size == 8;
 
         [DllImport("kernel32.dll")]
         public static extern int GetCurrentThreadId();
@@ -156,36 +154,36 @@ namespace CoreHook.Unmanaged.Windows
         public static extern int GetCurrentProcessId();
 
         [DllImport("kernel32.dll", CharSet = CharSet.Ansi)]
-        public static extern IntPtr GetProcAddress(IntPtr InModule, String InProcName);
+        public static extern IntPtr GetProcAddress(IntPtr InModule, string InProcName);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        public static extern IntPtr LoadLibrary(String InPath);
+        public static extern IntPtr LoadLibrary(string InPath);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        public static extern IntPtr GetModuleHandle(String InPath);
+        public static extern IntPtr GetModuleHandle(string InPath);
 
         [DllImport("kernel32.dll")]
-        public static extern Int16 RtlCaptureStackBackTrace(
-            Int32 InFramesToSkip,
-            Int32 InFramesToCapture,
+        public static extern short RtlCaptureStackBackTrace(
+            int InFramesToSkip,
+            int InFramesToCapture,
             IntPtr OutBackTrace,
             IntPtr OutBackTraceHash);
 
-        public const Int32 STATUS_SUCCESS = unchecked((Int32)0);
-        public const Int32 STATUS_INVALID_PARAMETER = unchecked((Int32)0xC000000DL);
-        public const Int32 STATUS_INVALID_PARAMETER_1 = unchecked((Int32)0xC00000EFL);
-        public const Int32 STATUS_INVALID_PARAMETER_2 = unchecked((Int32)0xC00000F0L);
-        public const Int32 STATUS_INVALID_PARAMETER_3 = unchecked((Int32)0xC00000F1L);
-        public const Int32 STATUS_INVALID_PARAMETER_4 = unchecked((Int32)0xC00000F2L);
-        public const Int32 STATUS_INVALID_PARAMETER_5 = unchecked((Int32)0xC00000F3L);
-        public const Int32 STATUS_NOT_SUPPORTED = unchecked((Int32)0xC00000BBL);
+        public const int STATUS_SUCCESS = unchecked((int)0);
+        public const int STATUS_INVALID_PARAMETER = unchecked((int)0xC000000DL);
+        public const int STATUS_INVALID_PARAMETER_1 = unchecked((int)0xC00000EFL);
+        public const int STATUS_INVALID_PARAMETER_2 = unchecked((int)0xC00000F0L);
+        public const int STATUS_INVALID_PARAMETER_3 = unchecked((int)0xC00000F1L);
+        public const int STATUS_INVALID_PARAMETER_4 = unchecked((int)0xC00000F2L);
+        public const int STATUS_INVALID_PARAMETER_5 = unchecked((int)0xC00000F3L);
+        public const int STATUS_NOT_SUPPORTED = unchecked((int)0xC00000BBL);
 
-        public const Int32 STATUS_INTERNAL_ERROR = unchecked((Int32)0xC00000E5L);
-        public const Int32 STATUS_INSUFFICIENT_RESOURCES = unchecked((Int32)0xC000009AL);
-        public const Int32 STATUS_BUFFER_TOO_SMALL = unchecked((Int32)0xC0000023L);
-        public const Int32 STATUS_NO_MEMORY = unchecked((Int32)0xC0000017L);
-        public const Int32 STATUS_WOW_ASSERTION = unchecked((Int32)0xC0009898L);
-        public const Int32 STATUS_ACCESS_DENIED = unchecked((Int32)0xC0000022L);
+        public const int STATUS_INTERNAL_ERROR = unchecked((int)0xC00000E5L);
+        public const int STATUS_INSUFFICIENT_RESOURCES = unchecked((int)0xC000009AL);
+        public const int STATUS_BUFFER_TOO_SMALL = unchecked((int)0xC0000023L);
+        public const int STATUS_NO_MEMORY = unchecked((int)0xC0000017L);
+        public const int STATUS_WOW_ASSERTION = unchecked((int)0xC0009898L);
+        public const int STATUS_ACCESS_DENIED = unchecked((int)0xC0000022L);
 
         [StructLayout(LayoutKind.Sequential)]
         public struct SECURITY_ATTRIBUTES
@@ -197,20 +195,20 @@ namespace CoreHook.Unmanaged.Windows
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public struct STARTUPINFO
         {
-            public Int32 cb;
+            public int cb;
             public string lpReserved;
             public string lpDesktop;
             public string lpTitle;
-            public Int32 dwX;
-            public Int32 dwY;
-            public Int32 dwXSize;
-            public Int32 dwYSize;
-            public Int32 dwXCountChars;
-            public Int32 dwYCountChars;
-            public Int32 dwFillAttribute;
-            public Int32 dwFlags;
-            public Int16 wShowWindow;
-            public Int16 cbReserved2;
+            public int dwX;
+            public int dwY;
+            public int dwXSize;
+            public int dwYSize;
+            public int dwXCountChars;
+            public int dwYCountChars;
+            public int dwFillAttribute;
+            public int dwFlags;
+            public short wShowWindow;
+            public short cbReserved2;
             public IntPtr lpReserved2;
             public IntPtr hStdInput;
             public IntPtr hStdOutput;
@@ -226,17 +224,17 @@ namespace CoreHook.Unmanaged.Windows
         }
  
         public static bool DetourCreateProcessWithDllExA(
-            String lpApplicationName,
-            String lpCommandLine,
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessA)
         {
             if (Is64Bit)
@@ -272,17 +270,17 @@ namespace CoreHook.Unmanaged.Windows
         }
 
         public static bool DetourCreateProcessWithDllExW(
-            String lpApplicationName,
-            String lpCommandLine,
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessW)
         {
             if (Is64Bit)
@@ -318,14 +316,14 @@ namespace CoreHook.Unmanaged.Windows
         }
 
         public static bool DetourCreateProcessWithDllsExA(
-            String lpApplicationName,
-            String lpCommandLine,
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
             uint nDlls,
@@ -367,14 +365,14 @@ namespace CoreHook.Unmanaged.Windows
         }
 
         public static bool DetourCreateProcessWithDllsExW(
-            String lpApplicationName,
-            String lpCommandLine,
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             ref NativeMethods.StartupInfo lpStartupInfo,
             out NativeMethods.ProcessInformation lpProcessInformation,
             uint nDlls,

--- a/CoreHook/DllImport.cs
+++ b/CoreHook/DllImport.cs
@@ -7,7 +7,7 @@ namespace CoreHook
 {
     static class NativeAPI_x86
     {
-        private const String DllName = "corehook32.dll";
+        private const string DllName = "corehook32.dll";
 
         internal static ILibLoader libLoader;
         internal static IntPtr libHandle;
@@ -42,15 +42,15 @@ namespace CoreHook
         }
 
 
-        public delegate String DRtlGetLastErrorStringCopy();
+        public delegate string DRtlGetLastErrorStringCopy();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern String RtlGetLastErrorStringCopy();
+        public static extern string RtlGetLastErrorStringCopy();
 
-        public delegate Int32 RtlGetLastError();
+        public delegate int RtlGetLastError();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 RtlGetLastErrorF();
+        public static extern int RtlGetLastErrorF();
 
         public delegate void LhUninstallAllHooks();
 
@@ -58,29 +58,29 @@ namespace CoreHook
         public static extern void LhUninstallAllHooksF();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhInstallHookF(
+        public static extern int LhInstallHookF(
             IntPtr InEntryPoint,
             IntPtr InHookProc,
             IntPtr InCallback,
             IntPtr OutHandle);
 
-        public delegate Int32 LhInstallHook(
+        public delegate int LhInstallHook(
             IntPtr InEntryPoint,
             IntPtr InHookProc,
             IntPtr InCallback,
             IntPtr OutHandle);
 
-        public delegate Int32 LhUninstallHook(IntPtr RefHandle);
+        public delegate int LhUninstallHook(IntPtr RefHandle);
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhUninstallHookF(IntPtr RefHandle);
+        public static extern int LhUninstallHookF(IntPtr RefHandle);
 
-        public delegate Int32 LhWaitForPendingRemovals();
+        public delegate int LhWaitForPendingRemovals();
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhWaitForPendingRemovalsF();
+        public static extern int LhWaitForPendingRemovalsF();
 
 
         /*
@@ -88,64 +88,64 @@ namespace CoreHook
             hook starts suspended. You will have to set a proper ACL to
             make it active!
         */
-        public delegate Int32 LhSetInclusiveACL(
+        public delegate int LhSetInclusiveACL(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount,
+                    int[] InThreadIdList,
+                    int InThreadCount,
                     IntPtr InHandle);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhSetInclusiveACLF(
+        public static extern int LhSetInclusiveACLF(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount,
+                    int[] InThreadIdList,
+                    int InThreadCount,
                     IntPtr InHandle);
 
-        public delegate Int32 LhSetExclusiveACL(
+        public delegate int LhSetExclusiveACL(
             [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-            Int32 InThreadCount,
+                    int[] InThreadIdList,
+            int InThreadCount,
             IntPtr InHandle);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhSetExclusiveACLF(
+        public static extern int LhSetExclusiveACLF(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount,
+                    int[] InThreadIdList,
+                    int InThreadCount,
                     IntPtr InHandle);
 
-        public delegate Int32 LhSetGlobalInclusiveACL(
+        public delegate int LhSetGlobalInclusiveACL(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount);
+                    int[] InThreadIdList,
+                    int InThreadCount);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhSetGlobalInclusiveACLF(
+        public static extern int LhSetGlobalInclusiveACLF(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount);
+                    int[] InThreadIdList,
+                    int InThreadCount);
 
-        public delegate Int32 LhSetGlobalExclusiveACL(
+        public delegate int LhSetGlobalExclusiveACL(
             [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-            Int32 InThreadCount);
+                    int[] InThreadIdList,
+            int InThreadCount);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhSetGlobalExclusiveACLF(
+        public static extern int LhSetGlobalExclusiveACLF(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount);
+                    int[] InThreadIdList,
+                    int InThreadCount);
 
-        public delegate Int32 LhIsThreadIntercepted(
+        public delegate int LhIsThreadIntercepted(
             IntPtr InHandle,
-            Int32 InThreadID,
-            out Boolean OutResult);
+            int InThreadID,
+            out bool OutResult);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhIsThreadInterceptedF(
+        public static extern int LhIsThreadInterceptedF(
                     IntPtr InHandle,
-                    Int32 InThreadID,
-                    out Boolean OutResult);
+                    int InThreadID,
+                    out bool OutResult);
 
         /*
             The following barrier methods are meant to be used in hook handlers only!
@@ -153,117 +153,117 @@ namespace CoreHook
             They will all fail with STATUS_NOT_SUPPORTED if called outside a
             valid hook handler...
         */
-        public delegate Int32 LhBarrierGetCallback(out IntPtr OutValue);
+        public delegate int LhBarrierGetCallback(out IntPtr OutValue);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierGetCallbackF(out IntPtr OutValue);
+        public static extern int LhBarrierGetCallbackF(out IntPtr OutValue);
 
-        public delegate Int32 LhBarrierGetReturnAddress(out IntPtr OutValue);
-
-
-        [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierGetReturnAddressF(out IntPtr OutValue);
-
-
-        public delegate Int32 LhBarrierGetAddressOfReturnAddress(out IntPtr OutValue);
+        public delegate int LhBarrierGetReturnAddress(out IntPtr OutValue);
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierGetAddressOfReturnAddressF(out IntPtr OutValue);
-
-        public delegate Int32 LhBarrierBeginStackTrace(out IntPtr OutBackup);
+        public static extern int LhBarrierGetReturnAddressF(out IntPtr OutValue);
 
 
-        [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierBeginStackTraceF(out IntPtr OutBackup);
-
-        public delegate Int32 LhBarrierEndStackTrace(IntPtr OutBackup);
+        public delegate int LhBarrierGetAddressOfReturnAddress(out IntPtr OutValue);
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierEndStackTraceF(IntPtr OutBackup);
+        public static extern int LhBarrierGetAddressOfReturnAddressF(out IntPtr OutValue);
 
-        public delegate Int32 LhBarrierGetCallingModule(out IntPtr OutValue);
+        public delegate int LhBarrierBeginStackTrace(out IntPtr OutBackup);
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierGetCallingModuleF(out IntPtr OutValue);
+        public static extern int LhBarrierBeginStackTraceF(out IntPtr OutBackup);
+
+        public delegate int LhBarrierEndStackTrace(IntPtr OutBackup);
+
+
+        [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
+        public static extern int LhBarrierEndStackTraceF(IntPtr OutBackup);
+
+        public delegate int LhBarrierGetCallingModule(out IntPtr OutValue);
+
+
+        [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
+        public static extern int LhBarrierGetCallingModuleF(out IntPtr OutValue);
 
         /*
             Debug helper API.
         */
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 DbgAttachDebugger();
+        public static extern int DbgAttachDebugger();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 DbgGetThreadIdByHandle(
+        public static extern int DbgGetThreadIdByHandle(
             IntPtr InThreadHandle,
-            out Int32 OutThreadId);
+            out int OutThreadId);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 DbgGetProcessIdByHandle(
+        public static extern int DbgGetProcessIdByHandle(
             IntPtr InProcessHandle,
-            out Int32 OutProcessId);
+            out int OutProcessId);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 DbgHandleToObjectName(
+        public static extern int DbgHandleToObjectName(
             IntPtr InNamedHandle,
             IntPtr OutNameBuffer,
-            Int32 InBufferSize,
-            out Int32 OutRequiredSize);
+            int InBufferSize,
+            out int OutRequiredSize);
 
 
         /*
             Injection support API.
         */
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Int32 RhInjectLibrary(
-            Int32 InTargetPID,
-            Int32 InWakeUpTID,
-            Int32 InInjectionOptions,
-            String InLibraryPath_x86,
-            String InLibraryPath_x64,
+        public static extern int RhInjectLibrary(
+            int InTargetPID,
+            int InWakeUpTID,
+            int InInjectionOptions,
+            string InLibraryPath_x86,
+            string InLibraryPath_x64,
             IntPtr InPassThruBuffer,
-            Int32 InPassThruSize);
+            int InPassThruSize);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 RhIsX64Process(
-            Int32 InProcessId,
-            out Boolean OutResult);
+        public static extern int RhIsX64Process(
+            int InProcessId,
+            out bool OutResult);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean RhIsAdministrator();
+        public static extern bool RhIsAdministrator();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 RhGetProcessToken(Int32 InProcessId, out IntPtr OutToken);
+        public static extern int RhGetProcessToken(int InProcessId, out IntPtr OutToken);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Int32 RtlInstallService(
-            String InServiceName,
-            String InExePath,
-            String InChannelName);
+        public static extern int RtlInstallService(
+            string InServiceName,
+            string InExePath,
+            string InChannelName);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 RhWakeUpProcess();
+        public static extern int RhWakeUpProcess();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Int32 RtlCreateSuspendedProcess(
-           String InEXEPath,
-           String InCommandLine,
-            Int32 InProcessCreationFlags,
-           out Int32 OutProcessId,
-           out Int32 OutThreadId);
+        public static extern int RtlCreateSuspendedProcess(
+           string InEXEPath,
+           string InCommandLine,
+            int InProcessCreationFlags,
+           out int OutProcessId,
+           out int OutThreadId);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Int32 RhInstallDriver(
-           String InDriverPath,
-           String InDriverName);
+        public static extern int RhInstallDriver(
+           string InDriverPath,
+           string InDriverName);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 RhInstallSupportDriver();
+        public static extern int RhInstallSupportDriver();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean RhIsX64System();
+        public static extern bool RhIsX64System();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
         public static extern IntPtr GacCreateContext();
@@ -274,16 +274,16 @@ namespace CoreHook
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public static extern bool GacInstallAssembly(
             IntPtr InContext,
-            String InAssemblyPath,
-            String InDescription,
-            String InUniqueID);
+            string InAssemblyPath,
+            string InDescription,
+            string InUniqueID);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public static extern bool GacUninstallAssembly(
             IntPtr InContext,
-            String InAssemblyName,
-            String InDescription,
-            String InUniqueID);
+            string InAssemblyName,
+            string InDescription,
+            string InUniqueID);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public static extern int LhGetHookBypassAddressF(IntPtr handle, out IntPtr address);
@@ -291,43 +291,43 @@ namespace CoreHook
         public delegate int LhGetHookBypassAddress(IntPtr handle, out IntPtr address);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Boolean DetourCreateProcessWithDllExW(String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllExW(string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessW);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
-        public static extern Boolean DetourCreateProcessWithDllExA(String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllExA(string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessW);
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Boolean DetourCreateProcessWithDllsExW(String lpApplicationName,
-              String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllsExW(string lpApplicationName,
+              string lpCommandLine,
               IntPtr lpProcessAttributes,
               IntPtr lpThreadAttributes,
               bool bInheritHandles,
               uint dwCreationFlags,
               IntPtr lpEnvironment,
-              String lpCurrentDirectory,
+              string lpCurrentDirectory,
               IntPtr lpStartupInfo,
               IntPtr lpProcessInformation,
               uint nDlls,
@@ -335,14 +335,14 @@ namespace CoreHook
               IntPtr pfCreateProcessW);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
-        public static extern Boolean DetourCreateProcessWithDllsExA(String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllsExA(string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
             uint nDlls,
@@ -365,7 +365,7 @@ namespace CoreHook
 
     static class NativeAPI_x64
     {
-        private const String DllName = "corehook64.dll";
+        private const string DllName = "corehook64.dll";
 
         internal static ILibLoader libLoader;
         internal static IntPtr libHandle;
@@ -406,15 +406,15 @@ namespace CoreHook
             libHandle = libLoader.LoadLibrary(map.Item2);
         }
 
-        public delegate String DRtlGetLastErrorStringCopy();
+        public delegate string DRtlGetLastErrorStringCopy();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern String RtlGetLastErrorStringCopy();
+        public static extern string RtlGetLastErrorStringCopy();
 
-        public delegate Int32 RtlGetLastError();
+        public delegate int RtlGetLastError();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 RtlGetLastErrorF();
+        public static extern int RtlGetLastErrorF();
 
         public delegate void LhUninstallAllHooks();
 
@@ -422,29 +422,29 @@ namespace CoreHook
         public static extern void LhUninstallAllHooksF();
         
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhInstallHookF(
+        public static extern int LhInstallHookF(
             IntPtr InEntryPoint,
             IntPtr InHookProc,
             IntPtr InCallback,
             IntPtr OutHandle);
 
-        public delegate Int32 LhInstallHook(
+        public delegate int LhInstallHook(
             IntPtr InEntryPoint,
             IntPtr InHookProc,
             IntPtr InCallback,
             IntPtr OutHandle);
 
-        public delegate Int32 LhUninstallHook(IntPtr RefHandle);
+        public delegate int LhUninstallHook(IntPtr RefHandle);
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhUninstallHookF(IntPtr RefHandle);
+        public static extern int LhUninstallHookF(IntPtr RefHandle);
 
-        public delegate Int32 LhWaitForPendingRemovals();
+        public delegate int LhWaitForPendingRemovals();
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhWaitForPendingRemovalsF();
+        public static extern int LhWaitForPendingRemovalsF();
 
 
         /*
@@ -452,64 +452,64 @@ namespace CoreHook
             hook starts suspended. You will have to set a proper ACL to
             make it active!
         */
-        public delegate Int32 LhSetInclusiveACL(
+        public delegate int LhSetInclusiveACL(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount,
+                    int[] InThreadIdList,
+                    int InThreadCount,
                     IntPtr InHandle);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhSetInclusiveACLF(
+        public static extern int LhSetInclusiveACLF(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount,
+                    int[] InThreadIdList,
+                    int InThreadCount,
                     IntPtr InHandle);
 
-        public delegate Int32 LhSetExclusiveACL(
+        public delegate int LhSetExclusiveACL(
             [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-            Int32 InThreadCount,
+                    int[] InThreadIdList,
+            int InThreadCount,
             IntPtr InHandle);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhSetExclusiveACLF(
+        public static extern int LhSetExclusiveACLF(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount,
+                    int[] InThreadIdList,
+                    int InThreadCount,
                     IntPtr InHandle);
 
-        public delegate Int32 LhSetGlobalInclusiveACL(
+        public delegate int LhSetGlobalInclusiveACL(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount);
+                    int[] InThreadIdList,
+                    int InThreadCount);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhSetGlobalInclusiveACLF(
+        public static extern int LhSetGlobalInclusiveACLF(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount);
+                    int[] InThreadIdList,
+                    int InThreadCount);
 
-        public delegate Int32 LhSetGlobalExclusiveACL(
+        public delegate int LhSetGlobalExclusiveACL(
             [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-            Int32 InThreadCount);
+                    int[] InThreadIdList,
+            int InThreadCount);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhSetGlobalExclusiveACLF(
+        public static extern int LhSetGlobalExclusiveACLF(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount);
+                    int[] InThreadIdList,
+                    int InThreadCount);
 
-        public delegate Int32 LhIsThreadIntercepted(
+        public delegate int LhIsThreadIntercepted(
             IntPtr InHandle,
-            Int32 InThreadID,
-            out Boolean OutResult);
+            int InThreadID,
+            out bool OutResult);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhIsThreadInterceptedF(
+        public static extern int LhIsThreadInterceptedF(
                     IntPtr InHandle,
-                    Int32 InThreadID,
-                    out Boolean OutResult);
+                    int InThreadID,
+                    out bool OutResult);
 
         /*
             The following barrier methods are meant to be used in hook handlers only!
@@ -517,117 +517,117 @@ namespace CoreHook
             They will all fail with STATUS_NOT_SUPPORTED if called outside a
             valid hook handler...
         */
-        public delegate Int32 LhBarrierGetCallback(out IntPtr OutValue);
+        public delegate int LhBarrierGetCallback(out IntPtr OutValue);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierGetCallbackF(out IntPtr OutValue);
+        public static extern int LhBarrierGetCallbackF(out IntPtr OutValue);
 
-        public delegate Int32 LhBarrierGetReturnAddress(out IntPtr OutValue);
-
-
-        [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierGetReturnAddressF(out IntPtr OutValue);
-
-
-        public delegate Int32 LhBarrierGetAddressOfReturnAddress(out IntPtr OutValue);
+        public delegate int LhBarrierGetReturnAddress(out IntPtr OutValue);
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierGetAddressOfReturnAddressF(out IntPtr OutValue);
-
-        public delegate Int32 LhBarrierBeginStackTrace(out IntPtr OutBackup);
+        public static extern int LhBarrierGetReturnAddressF(out IntPtr OutValue);
 
 
-        [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierBeginStackTraceF(out IntPtr OutBackup);
-
-        public delegate Int32 LhBarrierEndStackTrace(IntPtr OutBackup);
+        public delegate int LhBarrierGetAddressOfReturnAddress(out IntPtr OutValue);
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierEndStackTraceF(IntPtr OutBackup);
+        public static extern int LhBarrierGetAddressOfReturnAddressF(out IntPtr OutValue);
 
-        public delegate Int32 LhBarrierGetCallingModule(out IntPtr OutValue);
+        public delegate int LhBarrierBeginStackTrace(out IntPtr OutBackup);
 
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 LhBarrierGetCallingModuleF(out IntPtr OutValue);
+        public static extern int LhBarrierBeginStackTraceF(out IntPtr OutBackup);
+
+        public delegate int LhBarrierEndStackTrace(IntPtr OutBackup);
+
+
+        [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
+        public static extern int LhBarrierEndStackTraceF(IntPtr OutBackup);
+
+        public delegate int LhBarrierGetCallingModule(out IntPtr OutValue);
+
+
+        [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
+        public static extern int LhBarrierGetCallingModuleF(out IntPtr OutValue);
 
         /*
             Debug helper API.
         */
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 DbgAttachDebugger();
+        public static extern int DbgAttachDebugger();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 DbgGetThreadIdByHandle(
+        public static extern int DbgGetThreadIdByHandle(
             IntPtr InThreadHandle,
-            out Int32 OutThreadId);
+            out int OutThreadId);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 DbgGetProcessIdByHandle(
+        public static extern int DbgGetProcessIdByHandle(
             IntPtr InProcessHandle,
-            out Int32 OutProcessId);
+            out int OutProcessId);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 DbgHandleToObjectName(
+        public static extern int DbgHandleToObjectName(
             IntPtr InNamedHandle,
             IntPtr OutNameBuffer,
-            Int32 InBufferSize,
-            out Int32 OutRequiredSize);
+            int InBufferSize,
+            out int OutRequiredSize);
 
 
         /*
             Injection support API.
         */
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Int32 RhInjectLibrary(
-            Int32 InTargetPID,
-            Int32 InWakeUpTID,
-            Int32 InInjectionOptions,
-            String InLibraryPath_x86,
-            String InLibraryPath_x64,
+        public static extern int RhInjectLibrary(
+            int InTargetPID,
+            int InWakeUpTID,
+            int InInjectionOptions,
+            string InLibraryPath_x86,
+            string InLibraryPath_x64,
             IntPtr InPassThruBuffer,
-            Int32 InPassThruSize);
+            int InPassThruSize);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 RhIsX64Process(
-            Int32 InProcessId,
-            out Boolean OutResult);
+        public static extern int RhIsX64Process(
+            int InProcessId,
+            out bool OutResult);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean RhIsAdministrator();
+        public static extern bool RhIsAdministrator();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 RhGetProcessToken(Int32 InProcessId, out IntPtr OutToken);
+        public static extern int RhGetProcessToken(int InProcessId, out IntPtr OutToken);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Int32 RtlInstallService(
-            String InServiceName,
-            String InExePath,
-            String InChannelName);
+        public static extern int RtlInstallService(
+            string InServiceName,
+            string InExePath,
+            string InChannelName);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Int32 RtlCreateSuspendedProcess(
-           String InEXEPath,
-           String InCommandLine,
-            Int32 InProcessCreationFlags,
-           out Int32 OutProcessId,
-           out Int32 OutThreadId);
+        public static extern int RtlCreateSuspendedProcess(
+           string InEXEPath,
+           string InCommandLine,
+            int InProcessCreationFlags,
+           out int OutProcessId,
+           out int OutThreadId);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 RhWakeUpProcess();
+        public static extern int RhWakeUpProcess();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Int32 RhInstallDriver(
-           String InDriverPath,
-           String InDriverName);
+        public static extern int RhInstallDriver(
+           string InDriverPath,
+           string InDriverName);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Int32 RhInstallSupportDriver();
+        public static extern int RhInstallSupportDriver();
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
-        public static extern Boolean RhIsX64System();
+        public static extern bool RhIsX64System();
         
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
         public static extern IntPtr GacCreateContext();
@@ -638,16 +638,16 @@ namespace CoreHook
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public static extern bool GacInstallAssembly(
             IntPtr InContext,
-            String InAssemblyPath,
-            String InDescription,
-            String InUniqueID);
+            string InAssemblyPath,
+            string InDescription,
+            string InUniqueID);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public static extern bool GacUninstallAssembly(
             IntPtr InContext,
-            String InAssemblyName,
-            String InDescription,
-            String InUniqueID);
+            string InAssemblyName,
+            string InDescription,
+            string InUniqueID);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public static extern int LhGetHookBypassAddressF(IntPtr handle, out IntPtr address);
@@ -655,85 +655,85 @@ namespace CoreHook
         public delegate int LhGetHookBypassAddress(IntPtr handle, out IntPtr address);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Boolean DetourCreateProcessWithDllExWF(String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllExWF(string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessW);
 
-        public delegate Boolean DetourCreateProcessWithDllExW(
-                        String lpApplicationName,
-                        String lpCommandLine,
+        public delegate bool DetourCreateProcessWithDllExW(
+                        string lpApplicationName,
+                        string lpCommandLine,
                         IntPtr lpProcessAttributes,
                         IntPtr lpThreadAttributes,
                         bool bInheritHandles,
                         uint dwCreationFlags,
                         IntPtr lpEnvironment,
-                        String lpCurrentDirectory,
+                        string lpCurrentDirectory,
                         IntPtr lpStartupInfo,
                         IntPtr lpProcessInformation,
-                        String lpDllName,
+                        string lpDllName,
                         IntPtr pfCreateProcessW);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
-        public static extern Boolean DetourCreateProcessWithDllExAF(String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllExAF(string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessW);
 
-        public delegate Boolean DetourCreateProcessWithDllExA(
-            String lpApplicationName,
-            String lpCommandLine,
+        public delegate bool DetourCreateProcessWithDllExA(
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessW);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public static extern Boolean DetourCreateProcessWithDllsExWF(String lpApplicationName,
-              String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllsExWF(string lpApplicationName,
+              string lpCommandLine,
               IntPtr lpProcessAttributes,
               IntPtr lpThreadAttributes,
               bool bInheritHandles,
               uint dwCreationFlags,
               IntPtr lpEnvironment,
-              String lpCurrentDirectory,
+              string lpCurrentDirectory,
               IntPtr lpStartupInfo,
               IntPtr lpProcessInformation,
               uint nDlls,
               IntPtr rlpDlls,
               IntPtr pfCreateProcessW);
 
-        public delegate Boolean DetourCreateProcessWithDllsExW(
-                        String lpApplicationName,
-                        String lpCommandLine,
+        public delegate bool DetourCreateProcessWithDllsExW(
+                        string lpApplicationName,
+                        string lpCommandLine,
                         IntPtr lpProcessAttributes,
                         IntPtr lpThreadAttributes,
                         bool bInheritHandles,
                         uint dwCreationFlags,
                         IntPtr lpEnvironment,
-                        String lpCurrentDirectory,
+                        string lpCurrentDirectory,
                         IntPtr lpStartupInfo,
                         IntPtr lpProcessInformation,
                         uint nDlls,
@@ -741,29 +741,29 @@ namespace CoreHook
                         IntPtr pfCreateProcessW);
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
-        public static extern Boolean DetourCreateProcessWithDllsExAF(String lpApplicationName,
-            String lpCommandLine,
+        public static extern bool DetourCreateProcessWithDllsExAF(string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
             uint nDlls,
             IntPtr rlpDlls,
             IntPtr pfCreateProcessW);
 
-        public delegate Boolean DetourCreateProcessWithDllsExA(
-            String lpApplicationName,
-            String lpCommandLine,
+        public delegate bool DetourCreateProcessWithDllsExA(
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
             uint nDlls,
@@ -777,9 +777,9 @@ namespace CoreHook
 
     public static class NativeAPI
     {
-        public const Int32 MAX_HOOK_COUNT = 1024;
-        public const Int32 MAX_ACE_COUNT = 128;
-        public readonly static Boolean Is64Bit = IntPtr.Size == 8;
+        public const int MAX_HOOK_COUNT = 1024;
+        public const int MAX_ACE_COUNT = 128;
+        public readonly static bool Is64Bit = IntPtr.Size == 8;
 
         [DllImport("kernel32.dll")]
         public static extern int GetCurrentThreadId();
@@ -791,36 +791,36 @@ namespace CoreHook
         public static extern int GetCurrentProcessId();
 
         [DllImport("kernel32.dll", CharSet = CharSet.Ansi)]
-        public static extern IntPtr GetProcAddress(IntPtr InModule, String InProcName);
+        public static extern IntPtr GetProcAddress(IntPtr InModule, string InProcName);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        public static extern IntPtr LoadLibrary(String InPath);
+        public static extern IntPtr LoadLibrary(string InPath);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        public static extern IntPtr GetModuleHandle(String InPath);
+        public static extern IntPtr GetModuleHandle(string InPath);
 
         [DllImport("kernel32.dll")]
-        public static extern Int16 RtlCaptureStackBackTrace(
-            Int32 InFramesToSkip,
-            Int32 InFramesToCapture,
+        public static extern short RtlCaptureStackBackTrace(
+            int InFramesToSkip,
+            int InFramesToCapture,
             IntPtr OutBackTrace,
             IntPtr OutBackTraceHash);
 
-        public const Int32 STATUS_SUCCESS = unchecked((Int32)0);
-        public const Int32 STATUS_INVALID_PARAMETER = unchecked((Int32)0xC000000DL);
-        public const Int32 STATUS_INVALID_PARAMETER_1 = unchecked((Int32)0xC00000EFL);
-        public const Int32 STATUS_INVALID_PARAMETER_2 = unchecked((Int32)0xC00000F0L);
-        public const Int32 STATUS_INVALID_PARAMETER_3 = unchecked((Int32)0xC00000F1L);
-        public const Int32 STATUS_INVALID_PARAMETER_4 = unchecked((Int32)0xC00000F2L);
-        public const Int32 STATUS_INVALID_PARAMETER_5 = unchecked((Int32)0xC00000F3L);
-        public const Int32 STATUS_NOT_SUPPORTED = unchecked((Int32)0xC00000BBL);
+        public const int STATUS_SUCCESS = unchecked((int)0);
+        public const int STATUS_INVALID_PARAMETER = unchecked((int)0xC000000DL);
+        public const int STATUS_INVALID_PARAMETER_1 = unchecked((int)0xC00000EFL);
+        public const int STATUS_INVALID_PARAMETER_2 = unchecked((int)0xC00000F0L);
+        public const int STATUS_INVALID_PARAMETER_3 = unchecked((int)0xC00000F1L);
+        public const int STATUS_INVALID_PARAMETER_4 = unchecked((int)0xC00000F2L);
+        public const int STATUS_INVALID_PARAMETER_5 = unchecked((int)0xC00000F3L);
+        public const int STATUS_NOT_SUPPORTED = unchecked((int)0xC00000BBL);
 
-        public const Int32 STATUS_INTERNAL_ERROR = unchecked((Int32)0xC00000E5L);
-        public const Int32 STATUS_INSUFFICIENT_RESOURCES = unchecked((Int32)0xC000009AL);
-        public const Int32 STATUS_BUFFER_TOO_SMALL = unchecked((Int32)0xC0000023L);
-        public const Int32 STATUS_NO_MEMORY = unchecked((Int32)0xC0000017L);
-        public const Int32 STATUS_WOW_ASSERTION = unchecked((Int32)0xC0009898L);
-        public const Int32 STATUS_ACCESS_DENIED = unchecked((Int32)0xC0000022L);
+        public const int STATUS_INTERNAL_ERROR = unchecked((int)0xC00000E5L);
+        public const int STATUS_INSUFFICIENT_RESOURCES = unchecked((int)0xC000009AL);
+        public const int STATUS_BUFFER_TOO_SMALL = unchecked((int)0xC0000023L);
+        public const int STATUS_NO_MEMORY = unchecked((int)0xC0000017L);
+        public const int STATUS_WOW_ASSERTION = unchecked((int)0xC0009898L);
+        public const int STATUS_ACCESS_DENIED = unchecked((int)0xC0000022L);
 
         private static T LoadFunction<T>(string name, ILibLoader loader, IntPtr handle) where T : class
         {
@@ -833,12 +833,12 @@ namespace CoreHook
             var arch = RuntimeInformation.ProcessArchitecture;
             return arch == Architecture.Arm || arch == Architecture.Arm64;
         }
-        private static String ComposeString()
+        private static string ComposeString()
         {
-            return String.Format("{0} (Code: {1})", RtlGetLastErrorString(), RtlGetLastError());
+            return string.Format("{0} (Code: {1})", RtlGetLastErrorString(), RtlGetLastError());
         }
 
-        internal static void Force(Int32 InErrorCode)
+        internal static void Force(int InErrorCode)
         {
             switch (InErrorCode)
             {
@@ -861,7 +861,7 @@ namespace CoreHook
             }
         }
 
-        public static Int32 RtlGetLastError()
+        public static int RtlGetLastError()
         {
             if (Is64Bit)
             {
@@ -881,7 +881,7 @@ namespace CoreHook
             }
         }
 
-        public static String RtlGetLastErrorString()
+        public static string RtlGetLastErrorString()
         {
             if (Is64Bit)
             {
@@ -987,8 +987,8 @@ namespace CoreHook
 
         public static void LhIsThreadIntercepted(
                     IntPtr InHandle,
-                    Int32 InThreadID,
-                    out Boolean OutResult)
+                    int InThreadID,
+                    out bool OutResult)
         {
             if (Is64Bit)
             {
@@ -1009,8 +1009,8 @@ namespace CoreHook
         }
 
         public static void LhSetInclusiveACL(
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount,
+                    int[] InThreadIdList,
+                    int InThreadCount,
                     IntPtr InHandle)
         {
             if (Is64Bit)
@@ -1032,8 +1032,8 @@ namespace CoreHook
         }
 
         public static void LhSetExclusiveACL(
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount,
+                    int[] InThreadIdList,
+                    int InThreadCount,
                     IntPtr InHandle)
         {
             if (Is64Bit)
@@ -1055,8 +1055,8 @@ namespace CoreHook
         }
 
         public static void LhSetGlobalInclusiveACL(
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount)
+                    int[] InThreadIdList,
+                    int InThreadCount)
         {
             if (Is64Bit)
             {
@@ -1077,8 +1077,8 @@ namespace CoreHook
         }
 
         public static void LhSetGlobalExclusiveACL(
-                    Int32[] InThreadIdList,
-                    Int32 InThreadCount)
+                    int[] InThreadIdList,
+                    int InThreadCount)
         {
             if (Is64Bit)
             {
@@ -1239,17 +1239,17 @@ namespace CoreHook
         }
 
         public static bool DetourCreateProcessWithDllExA(
-            String lpApplicationName,
-            String lpCommandLine,
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessW)
         {
             if (Is64Bit)
@@ -1288,17 +1288,17 @@ namespace CoreHook
             }
         }
         public static bool DetourCreateProcessWithDllExW(
-            String lpApplicationName,
-            String lpCommandLine,
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
-            String lpDllName,
+            string lpDllName,
             IntPtr pfCreateProcessW)
         {
             if (Is64Bit)
@@ -1337,14 +1337,14 @@ namespace CoreHook
             }
         }
         public static bool DetourCreateProcessWithDllsExA(
-            String lpApplicationName,
-            String lpCommandLine,
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
             uint nDlls,
@@ -1389,14 +1389,14 @@ namespace CoreHook
             }
         }
         public static bool DetourCreateProcessWithDllsExW(
-            String lpApplicationName,
-            String lpCommandLine,
+            string lpApplicationName,
+            string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
             bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
-            String lpCurrentDirectory,
+            string lpCurrentDirectory,
             IntPtr lpStartupInfo,
             IntPtr lpProcessInformation,
             uint nDlls,
@@ -1470,7 +1470,7 @@ namespace CoreHook
 
         public static void DbgGetThreadIdByHandle(
             IntPtr InThreadHandle,
-            out Int32 OutThreadId)
+            out int OutThreadId)
         {
             if (Is64Bit) Force(NativeAPI_x64.DbgGetThreadIdByHandle(InThreadHandle, out OutThreadId));
             else Force(NativeAPI_x86.DbgGetThreadIdByHandle(InThreadHandle, out OutThreadId));
@@ -1478,7 +1478,7 @@ namespace CoreHook
 
         public static void DbgGetProcessIdByHandle(
             IntPtr InProcessHandle,
-            out Int32 OutProcessId)
+            out int OutProcessId)
         {
             if (Is64Bit) Force(NativeAPI_x64.DbgGetProcessIdByHandle(InProcessHandle, out OutProcessId));
             else Force(NativeAPI_x86.DbgGetProcessIdByHandle(InProcessHandle, out OutProcessId));
@@ -1487,24 +1487,24 @@ namespace CoreHook
         public static void DbgHandleToObjectName(
             IntPtr InNamedHandle,
             IntPtr OutNameBuffer,
-            Int32 InBufferSize,
-            out Int32 OutRequiredSize)
+            int InBufferSize,
+            out int OutRequiredSize)
         {
             if (Is64Bit) Force(NativeAPI_x64.DbgHandleToObjectName(InNamedHandle, OutNameBuffer, InBufferSize, out OutRequiredSize));
             else Force(NativeAPI_x86.DbgHandleToObjectName(InNamedHandle, OutNameBuffer, InBufferSize, out OutRequiredSize));
         }
 
-        public static Int32 EASYHOOK_INJECT_DEFAULT = 0x00000000;
-        public static Int32 EASYHOOK_INJECT_MANAGED = 0x00000001;
+        public static int EASYHOOK_INJECT_DEFAULT = 0x00000000;
+        public static int EASYHOOK_INJECT_MANAGED = 0x00000001;
 
-        public static Int32 RhInjectLibraryEx(
-            Int32 InTargetPID,
-            Int32 InWakeUpTID,
-            Int32 InInjectionOptions,
-            String InLibraryPath_x86,
-            String InLibraryPath_x64,
+        public static int RhInjectLibraryEx(
+            int InTargetPID,
+            int InWakeUpTID,
+            int InInjectionOptions,
+            string InLibraryPath_x86,
+            string InLibraryPath_x64,
             IntPtr InPassThruBuffer,
-            Int32 InPassThruSize)
+            int InPassThruSize)
         {
             if (Is64Bit) return NativeAPI_x64.RhInjectLibrary(InTargetPID, InWakeUpTID, InInjectionOptions,
                 InLibraryPath_x86, InLibraryPath_x64, InPassThruBuffer, InPassThruSize);
@@ -1513,13 +1513,13 @@ namespace CoreHook
         }
 
         public static void RhInjectLibrary(
-            Int32 InTargetPID,
-            Int32 InWakeUpTID,
-            Int32 InInjectionOptions,
-            String InLibraryPath_x86,
-            String InLibraryPath_x64,
+            int InTargetPID,
+            int InWakeUpTID,
+            int InInjectionOptions,
+            string InLibraryPath_x86,
+            string InLibraryPath_x64,
             IntPtr InPassThruBuffer,
-            Int32 InPassThruSize)
+            int InPassThruSize)
         {
             if (Is64Bit) Force(NativeAPI_x64.RhInjectLibrary(InTargetPID, InWakeUpTID, InInjectionOptions,
                 InLibraryPath_x86, InLibraryPath_x64, InPassThruBuffer, InPassThruSize));
@@ -1528,11 +1528,11 @@ namespace CoreHook
         }
 
         public static void RtlCreateSuspendedProcess(
-           String InEXEPath,
-           String InCommandLine,
-            Int32 InProcessCreationFlags,
-           out Int32 OutProcessId,
-           out Int32 OutThreadId)
+           string InEXEPath,
+           string InCommandLine,
+            int InProcessCreationFlags,
+           out int OutProcessId,
+           out int OutThreadId)
         {
             if (Is64Bit) Force(NativeAPI_x64.RtlCreateSuspendedProcess(InEXEPath, InCommandLine, InProcessCreationFlags,
                 out OutProcessId, out OutThreadId));
@@ -1541,20 +1541,20 @@ namespace CoreHook
         }
 
         public static void RhIsX64Process(
-            Int32 InProcessId,
-            out Boolean OutResult)
+            int InProcessId,
+            out bool OutResult)
         {
             if (Is64Bit) Force(NativeAPI_x64.RhIsX64Process(InProcessId, out OutResult));
             else Force(NativeAPI_x86.RhIsX64Process(InProcessId, out OutResult));
         }
 
-        public static Boolean RhIsAdministrator()
+        public static bool RhIsAdministrator()
         {
             if (Is64Bit) return NativeAPI_x64.RhIsAdministrator();
             else return NativeAPI_x86.RhIsAdministrator();
         }
 
-        public static void RhGetProcessToken(Int32 InProcessId, out IntPtr OutToken)
+        public static void RhGetProcessToken(int InProcessId, out IntPtr OutToken)
         {
             if (Is64Bit) Force(NativeAPI_x64.RhGetProcessToken(InProcessId, out OutToken));
             else Force(NativeAPI_x86.RhGetProcessToken(InProcessId, out OutToken));
@@ -1567,17 +1567,17 @@ namespace CoreHook
         }
 
         public static void RtlInstallService(
-            String InServiceName,
-            String InExePath,
-            String InChannelName)
+            string InServiceName,
+            string InExePath,
+            string InChannelName)
         {
             if (Is64Bit) Force(NativeAPI_x64.RtlInstallService(InServiceName, InExePath, InChannelName));
             else Force(NativeAPI_x86.RtlInstallService(InServiceName, InExePath, InChannelName));
         }
 
         public static void RhInstallDriver(
-           String InDriverPath,
-           String InDriverName)
+           string InDriverPath,
+           string InDriverName)
         {
             if (Is64Bit) Force(NativeAPI_x64.RhInstallDriver(InDriverPath, InDriverName));
             else Force(NativeAPI_x86.RhInstallDriver(InDriverPath, InDriverName));
@@ -1589,7 +1589,7 @@ namespace CoreHook
             else Force(NativeAPI_x86.RhInstallSupportDriver());
         }
 
-        public static Boolean RhIsX64System()
+        public static bool RhIsX64System()
         {
             if (Is64Bit) return NativeAPI_x64.RhIsX64System();
             else return NativeAPI_x86.RhIsX64System();

--- a/CoreHook/ImportUtils/LibLoaderUnix.cs
+++ b/CoreHook/ImportUtils/LibLoaderUnix.cs
@@ -32,10 +32,10 @@ namespace CoreHook.ImportUtils
         const int RTLD_NOW = 2;
 
         [DllImport("libdl.so")]
-        private static extern IntPtr dlopen(String fileName, int flags);
+        private static extern IntPtr dlopen(string fileName, int flags);
 
         [DllImport("libdl.so")]
-        private static extern IntPtr dlsym(IntPtr handle, String symbol);
+        private static extern IntPtr dlsym(IntPtr handle, string symbol);
 
         [DllImport("libdl.so")]
         private static extern int dlclose(IntPtr handle);

--- a/CoreHook/LocalHook.cs
+++ b/CoreHook/LocalHook.cs
@@ -21,18 +21,18 @@ namespace CoreHook
     /// </remarks>
     public class HookAccessControl
     {
-        private Int32[] m_ACL = new Int32[0];
+        private int[] m_ACL = new int[0];
         private IntPtr m_Handle;
-        private Boolean m_IsExclusive;
+        private bool m_IsExclusive;
 
         /// <summary>
         /// Is this ACL an exclusive one? Refer to <see cref="SetExclusiveACL"/> for more information.
         /// </summary>
-        public Boolean IsExclusive { get { return m_IsExclusive; } }
+        public bool IsExclusive { get { return m_IsExclusive; } }
         /// <summary>
         /// Is this ACL an inclusive one? Refer to <see cref="SetInclusiveACL"/> for more information.
         /// </summary>
-        public Boolean IsInclusive { get { return !IsExclusive; } }
+        public bool IsInclusive { get { return !IsExclusive; } }
 
         /// <summary>
         /// Sets an inclusive ACL. This means all threads that are enumerated through <paramref name="InACL"/>
@@ -48,12 +48,12 @@ namespace CoreHook
         /// <exception cref="ArgumentException">
         /// The limit of 128 access entries is exceeded!
         /// </exception>
-        public void SetInclusiveACL(Int32[] InACL)
+        public void SetInclusiveACL(int[] InACL)
         {
             if (InACL == null)
-                m_ACL = new Int32[0];
+                m_ACL = new int[0];
             else
-                m_ACL = (Int32[])InACL.Clone();
+                m_ACL = (int[])InACL.Clone();
 
             m_IsExclusive = false;
 
@@ -77,12 +77,12 @@ namespace CoreHook
         /// <exception cref="ArgumentException">
         /// The limit of 128 access entries is exceeded!
         /// </exception>
-        public void SetExclusiveACL(Int32[] InACL)
+        public void SetExclusiveACL(int[] InACL)
         {
             if (InACL == null)
-                m_ACL = new Int32[0];
+                m_ACL = new int[0];
             else
-                m_ACL = (Int32[])InACL.Clone();
+                m_ACL = (int[])InACL.Clone();
 
             m_IsExclusive = true;
 
@@ -99,9 +99,9 @@ namespace CoreHook
         /// <returns>
         /// A copy of the internal thread entries.
         /// </returns>
-        public Int32[] GetEntries()
+        public int[] GetEntries()
         {
-            return (Int32[])m_ACL.Clone();
+            return (int[])m_ACL.Clone();
         }
 
         internal HookAccessControl(IntPtr InHandle)
@@ -126,14 +126,14 @@ namespace CoreHook
     public class HookRuntimeInfo
     {
         private static ProcessModule[] ModuleArray = new ProcessModule[0];
-        private static Int64 LastUpdate = 0;
+        private static long LastUpdate = 0;
 
         /// <summary>
         ///	Is the current thread within a valid hook handler? This is only the case
         ///	if your handler was called through the hooked entry point...
         ///	Executes in max. one micro secound.
         /// </summary>
-        public static Boolean IsHandlerContext
+        public static bool IsHandlerContext
         {
             get
             {
@@ -154,7 +154,7 @@ namespace CoreHook
         /// Executes in max. one micro secound.
         ///	</summary>
         ///	<exception cref="NotSupportedException"> The current thread is not within a valid hook handler. </exception>
-        public static Object Callback
+        public static object Callback
         {
             get
             {
@@ -212,7 +212,7 @@ namespace CoreHook
         /// <returns></returns>
         public static ProcessModule PointerToModule(IntPtr InPointer)
         {
-            Int64 Pointer = InPointer.ToInt64();
+            long Pointer = InPointer.ToInt64();
 
             if ((Pointer == 0) || (Pointer == ~0))
                 return null;
@@ -334,7 +334,7 @@ namespace CoreHook
                 Modules = new ProcessModule[64];
             }
 
-            public void Synchronize(Int32 InCount)
+            public void Synchronize(int InCount)
             {
                 Marshal.Copy(Unmanaged, Managed, 0, Math.Min(64, InCount));
             }
@@ -384,7 +384,7 @@ namespace CoreHook
                     if (StackBuffer == null)
                         StackBuffer = new StackTraceBuffer();
 
-                    Int16 Count = NativeAPI.RtlCaptureStackBackTrace(0, 32, StackBuffer.Unmanaged, IntPtr.Zero);
+                    short Count = NativeAPI.RtlCaptureStackBackTrace(0, 32, StackBuffer.Unmanaged, IntPtr.Zero);
                     ProcessModule[] Result = new ProcessModule[Count];
 
                     StackBuffer.Synchronize(Count);
@@ -443,11 +443,11 @@ namespace CoreHook
     /// </summary>
     public partial class LocalHook : CriticalFinalizerObject, IDisposable
     {
-        private Object m_ThreadSafe = new Object();
+        private object m_ThreadSafe = new object();
         private IntPtr m_Handle = IntPtr.Zero;
         private GCHandle m_SelfHandle;
         private Delegate m_HookProc;
-        private Object m_Callback;
+        private object m_Callback;
         private HookAccessControl m_ThreadACL;
         private static HookAccessControl m_GlobalThreadACL = new HookAccessControl(IntPtr.Zero);
 
@@ -464,7 +464,7 @@ namespace CoreHook
         /// <summary>
         /// The callback passed to <see cref="Create"/>.
         /// </summary>
-        public Object Callback { get { return m_Callback; } }
+        public object Callback { get { return m_Callback; } }
 
         /// <summary>
         /// Returns the thread ACL associated with this hook. Refer to <see cref="IsThreadIntercepted"/>
@@ -558,9 +558,9 @@ namespace CoreHook
         /// <exception cref="ObjectDisposedException">
         /// The underlying hook is already disposed.
         /// </exception>
-        public bool IsThreadIntercepted(Int32 InThreadID)
+        public bool IsThreadIntercepted(int InThreadID)
         {
-            Boolean Result;
+            bool Result;
 
             if (IntPtr.Zero == m_Handle)
                 throw new ObjectDisposedException(typeof(LocalHook).FullName);
@@ -656,7 +656,7 @@ namespace CoreHook
         public static LocalHook Create(
             IntPtr InTargetProc,
             Delegate InNewProc,
-            Object InCallback)
+            object InCallback)
         {
             LocalHook Result = new LocalHook();
 
@@ -795,8 +795,8 @@ namespace CoreHook
         /// The given module does not export the desired method.
         /// </exception>
         public static IntPtr GetProcAddress(
-            String InModule,
-            String InSymbolName)
+            string InModule,
+            string InSymbolName)
         {
             if(InModule == null)
             {
@@ -838,10 +838,10 @@ namespace CoreHook
         /// The given module does not export the given method.
         /// </exception>
         public static TDelegate GetProcDelegate<TDelegate>(
-            String InModule,
-            String InSymbolName)
+            string InModule,
+            string InSymbolName)
         {
-            return (TDelegate)(Object)Marshal.GetDelegateForFunctionPointer(GetProcAddress(InModule, InSymbolName), typeof(TDelegate));
+            return (TDelegate)(object)Marshal.GetDelegateForFunctionPointer(GetProcAddress(InModule, InSymbolName), typeof(TDelegate));
         }
 
         /// <summary>

--- a/Examples/CoreHook.FileMonitor/Program.cs
+++ b/Examples/CoreHook.FileMonitor/Program.cs
@@ -31,7 +31,7 @@ namespace CoreHook.FileMonitor
             int targetPID = 0;
             string targetProgam = string.Empty;
             // Load the parameter
-            while ((args.Length != 1) || !Int32.TryParse(args[0], out targetPID) || !File.Exists(args[0]))
+            while ((args.Length != 1) || !int.TryParse(args[0], out targetPID) || !File.Exists(args[0]))
             {
                 if (targetPID > 0)
                 {
@@ -47,7 +47,10 @@ namespace CoreHook.FileMonitor
 
                     args = new string[] { Console.ReadLine() };
 
-                    if (String.IsNullOrEmpty(args[0])) return;
+                    if (string.IsNullOrEmpty(args[0]))
+                    {
+                        return;
+                    }
                 }
                 else
                 {
@@ -115,13 +118,13 @@ namespace CoreHook.FileMonitor
                 Console.WriteLine("Cannot find corehook dll");
                 return;
             }
-            var currentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string currentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-            var coreLibrariesPath = GetCoreLibrariesPath();
-            var coreRootPath = GetCoreRootPath();
+            string coreLibrariesPath = GetCoreLibrariesPath();
+            string coreRootPath = GetCoreRootPath();
 
             // path to CoreRunDLL.dll
-            var coreRunDll = Path.Combine(currentDir,
+            string coreRunDll = Path.Combine(currentDir,
                 Environment.Is64BitProcess ? "CoreRunDLL64.dll" : "CoreRunDLL32.dll");
             if (!File.Exists(coreRunDll))
             {
@@ -134,7 +137,7 @@ namespace CoreHook.FileMonitor
             }
 
             // path to CoreHook.CoreLoad.dll
-            var coreLoadDll = Path.Combine(currentDir, "CoreHook.CoreLoad.dll");
+            string coreLoadDll = Path.Combine(currentDir, "CoreHook.CoreLoad.dll");
 
             if (!File.Exists(coreLoadDll))
             {
@@ -142,7 +145,7 @@ namespace CoreHook.FileMonitor
                 return;
             }
 
-            int processId;
+
             RemoteHooking.CreateAndInject(
                 exePath,
                 coreHookDll,
@@ -154,7 +157,7 @@ namespace CoreHook.FileMonitor
                 0,
                 injectionLibrary,
                 injectionLibrary,
-                out processId,
+                out _,
                 new PipePlatform(),
                 null,
                 CoreHookPipeName);
@@ -166,15 +169,15 @@ namespace CoreHook.FileMonitor
                 Console.WriteLine("Cannot find corehook dll");
                 return;
             }
-            var currentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string currentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
             // info on these environment variables: 
             // https://github.com/dotnet/coreclr/blob/master/Documentation/workflow/UsingCoreRun.md
-            var coreLibrariesPath = GetCoreLibrariesPath();
-            var coreRootPath = GetCoreRootPath();
+            string coreLibrariesPath = GetCoreLibrariesPath();
+            string coreRootPath = GetCoreRootPath();
 
             // path to CoreRunDLL.dll
-            var coreRunDll = Path.Combine(currentDir,
+            string coreRunDll = Path.Combine(currentDir,
                 Environment.Is64BitProcess ? "CoreRunDLL64.dll" : "CoreRunDLL32.dll");
             if (!File.Exists(coreRunDll))
             {
@@ -187,7 +190,7 @@ namespace CoreHook.FileMonitor
             }
 
             // path to CoreHook.CoreLoad.dll
-            var coreLoadDll = Path.Combine(currentDir, "CoreHook.CoreLoad.dll");
+            string coreLoadDll = Path.Combine(currentDir, "CoreHook.CoreLoad.dll");
 
             if (!File.Exists(coreLoadDll))
             {
@@ -210,9 +213,9 @@ namespace CoreHook.FileMonitor
 
         private static void StartListener()
         {
-            var _listener = new NpListener(CoreHookPipeName, pipePlatform);
-            _listener.RequestRetrieved += ClientConnectionMade;
-            _listener.Start();
+            var listener = new NpListener(CoreHookPipeName, pipePlatform);
+            listener.RequestRetrieved += ClientConnectionMade;
+            listener.Start();
 
             Console.WriteLine("Press Enter to quit.");
             Console.ReadLine();
@@ -222,7 +225,7 @@ namespace CoreHook.FileMonitor
         {
             var pipeServer = args.PipeStream;
 
-            var host = BuildServiceHost();
+            IJsonRpcServiceHost host = BuildServiceHost();
 
             var serverHandler = new StreamRpcServerHandler(host);
 

--- a/Examples/UWP/CoreHook.UWP.FileMonitor.Hook/Library.cs
+++ b/Examples/UWP/CoreHook.UWP.FileMonitor.Hook/Library.cs
@@ -55,7 +55,7 @@ namespace CoreHook.UWP.FileMonitor.Hook
             // Wait for the client to exit.
             clientTask.GetAwaiter().GetResult();
         }
-        Stack<String> Queue = new Stack<String>();
+        Queue<string> Queue = new Queue<string>();
 
         LocalHook CreateFileHook;
 
@@ -63,10 +63,10 @@ namespace CoreHook.UWP.FileMonitor.Hook
             CharSet = CharSet.Unicode,
             SetLastError = true)]
         delegate IntPtr DCreateFile2(
-            String InFileName,
-            UInt32 InDesiredAccess,
-            UInt32 InShareMode,
-            UInt32 InCreationDisposition,
+            string InFileName,
+            uint InDesiredAccess,
+            uint InShareMode,
+            uint InCreationDisposition,
             IntPtr pCreateExParams);
 
         [DllImport("kernelbase.dll",
@@ -74,18 +74,18 @@ namespace CoreHook.UWP.FileMonitor.Hook
         SetLastError = true,
         CallingConvention = CallingConvention.StdCall)]
         static extern IntPtr CreateFile2(
-            String InFileName,
-            UInt32 InDesiredAccess,
-            UInt32 InShareMode,
-            UInt32 InCreationDisposition,
+            string InFileName,
+            uint InDesiredAccess,
+            uint InShareMode,
+            uint InCreationDisposition,
             IntPtr pCreateExParams);
 
         // this is where we are intercepting all file accesses!
         private static IntPtr CreateFile2_Hooked(
-           String InFileName,
-           UInt32 InDesiredAccess,
-           UInt32 InShareMode,
-           UInt32 InCreationDisposition,
+           string InFileName,
+           uint InDesiredAccess,
+           uint InShareMode,
+           uint InCreationDisposition,
            IntPtr pCreateExParams)
         { 
             ClientWriteLine(string.Format("Creating file: '{0}'...", InFileName));
@@ -97,7 +97,7 @@ namespace CoreHook.UWP.FileMonitor.Hook
                 {
                     lock (This.Queue)
                     {
-                        This.Queue.Push(InFileName);
+                        This.Queue.Enqueue(InFileName);
                     }
                 }
             }
@@ -125,7 +125,7 @@ namespace CoreHook.UWP.FileMonitor.Hook
                 new DCreateFile2(CreateFile2_Hooked),
                 this);
 
-            CreateFileHook.ThreadACL.SetExclusiveACL(new Int32[] { 0 });
+            CreateFileHook.ThreadACL.SetExclusiveACL(new int[] { 0 });
         }
 
         private async Task RunClientAsync(Stream clientStream)

--- a/Examples/UWP/CoreHook.UWP.FileMonitor/ApplicationManager.cs
+++ b/Examples/UWP/CoreHook.UWP.FileMonitor/ApplicationManager.cs
@@ -22,19 +22,19 @@ namespace CoreHook.UWP.FileMonitor
     {
         // Activates the specified immersive application for the "Launch" contract, passing the provided arguments
         // string into the application.  Callers can obtain the process Id of the application instance fulfilling this contract.
-        IntPtr ActivateApplication([In] String appUserModelId, [In] String arguments, [In] ActivateOptions options, [Out] out UInt32 processId);
-        IntPtr ActivateForFile([In] String appUserModelId, [In] IntPtr /*IShellItemArray* */ itemArray, [In] String verb, [Out] out UInt32 processId);
-        IntPtr ActivateForProtocol([In] String appUserModelId, [In] IntPtr /* IShellItemArray* */itemArray, [Out] out UInt32 processId);
+        IntPtr ActivateApplication([In] string appUserModelId, [In] string arguments, [In] ActivateOptions options, [Out] out uint processId);
+        IntPtr ActivateForFile([In] string appUserModelId, [In] IntPtr /*IShellItemArray* */ itemArray, [In] string verb, [Out] out uint processId);
+        IntPtr ActivateForProtocol([In] string appUserModelId, [In] IntPtr /* IShellItemArray* */itemArray, [Out] out uint processId);
     }
 
     [ComImport, Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]//Application Activation Manager
     class ApplicationActivationManager : IApplicationActivationManager
     {
         [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)/*, PreserveSig*/]
-        public extern IntPtr ActivateApplication([In] String appUserModelId, [In] String arguments, [In] ActivateOptions options, [Out] out UInt32 processId);
+        public extern IntPtr ActivateApplication([In] string appUserModelId, [In] string arguments, [In] ActivateOptions options, [Out] out uint processId);
         [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
-        public extern IntPtr ActivateForFile([In] String appUserModelId, [In] IntPtr /*IShellItemArray* */ itemArray, [In] String verb, [Out] out UInt32 processId);
+        public extern IntPtr ActivateForFile([In] string appUserModelId, [In] IntPtr /*IShellItemArray* */ itemArray, [In] string verb, [Out] out uint processId);
         [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
-        public extern IntPtr ActivateForProtocol([In] String appUserModelId, [In] IntPtr /* IShellItemArray* */itemArray, [Out] out UInt32 processId);
+        public extern IntPtr ActivateForProtocol([In] string appUserModelId, [In] IntPtr /* IShellItemArray* */itemArray, [Out] out uint processId);
     }
 }

--- a/Examples/UWP/CoreHook.UWP.FileMonitor/Program.cs
+++ b/Examples/UWP/CoreHook.UWP.FileMonitor/Program.cs
@@ -42,7 +42,7 @@ namespace CoreHook.UWP.FileMonitor
             string targetApp = string.Empty;
 
             // Load the parameter
-            while ((args.Length != 1) || !Int32.TryParse(args[0], out targetPID))
+            while ((args.Length != 1) || !int.TryParse(args[0], out targetPID))
             {
                 if (targetPID > 0)
                 {
@@ -58,7 +58,10 @@ namespace CoreHook.UWP.FileMonitor
 
                     args = new string[] { Console.ReadLine() };
 
-                    if (String.IsNullOrEmpty(args[0])) return;
+                    if (string.IsNullOrEmpty(args[0]))
+                    {
+                        return;
+                    }
                 }
                 else
                 {
@@ -110,7 +113,7 @@ namespace CoreHook.UWP.FileMonitor
 
         private static string GetCoreRootPath()
         {
-            return  !IsArchitectureArm() ?
+            return !IsArchitectureArm() ?
              Environment.Is64BitProcess ?
              Environment.GetEnvironmentVariable("CORE_ROOT_64") :
              Environment.GetEnvironmentVariable("CORE_ROOT_32")
@@ -125,13 +128,13 @@ namespace CoreHook.UWP.FileMonitor
                 return;
             }
 
-            var currentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string currentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-            var coreLibrariesPath = GetCoreLibrariesPath();
-            var coreRootPath = GetCoreRootPath();
+            string coreLibrariesPath = GetCoreLibrariesPath();
+            string coreRootPath = GetCoreRootPath();
 
             // path to CoreRunDLL.dll
-            var coreRunDll = Path.Combine(currentDir,
+            string coreRunDll = Path.Combine(currentDir,
                 Environment.Is64BitProcess ? "CoreRunDLL64.dll" : "CoreRunDLL32.dll");
             if (!File.Exists(coreRunDll))
             {
@@ -143,7 +146,7 @@ namespace CoreHook.UWP.FileMonitor
                 }
             }
             // path to CoreHook.CoreLoad.dll
-            var coreLoadDll = Path.Combine(currentDir, "CoreHook.CoreLoad.dll");
+            string coreLoadDll = Path.Combine(currentDir, "CoreHook.CoreLoad.dll");
 
             if (!File.Exists(coreLoadDll))
             {
@@ -166,9 +169,9 @@ namespace CoreHook.UWP.FileMonitor
 
         private static void StartListener()
         {
-            var _listener = new NpListener(CoreHookPipeName, pipePlatform);
-            _listener.RequestRetrieved += ClientConnectionMade;
-            _listener.Start();
+            var listener = new NpListener(CoreHookPipeName, pipePlatform);
+            listener.RequestRetrieved += ClientConnectionMade;
+            listener.Start();
 
             Console.WriteLine("Press Enter to quit.");
             Console.ReadLine();
@@ -178,7 +181,7 @@ namespace CoreHook.UWP.FileMonitor
         {
             var pipeServer = args.PipeStream;
 
-            var host = BuildServiceHost();
+            IJsonRpcServiceHost host = BuildServiceHost();
 
             var serverHandler = new StreamRpcServerHandler(host);
 
@@ -215,7 +218,9 @@ namespace CoreHook.UWP.FileMonitor
         private static void GrantAllAppPkgsAccessToDir(string directory)
         {
             if (!Directory.Exists(directory))
+            {
                 return;
+            }
 
             GrantAllAppPkgsAccessToFile(directory);
             foreach (var file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories)
@@ -229,7 +234,7 @@ namespace CoreHook.UWP.FileMonitor
             try
             {
                 var fInfo = new FileInfo(fileName);
-                var acl = fInfo.GetAccessControl();
+                FileSecurity acl = fInfo.GetAccessControl();
 
                 var rule = new FileSystemAccessRule(new SecurityIdentifier("S-1-15-2-1"), FileSystemRights.ReadAndExecute, AccessControlType.Allow);
                 acl.SetAccessRule(rule);

--- a/Examples/Unix/CoreHook.Unix.FileMonitor.Hook/Library.cs
+++ b/Examples/Unix/CoreHook.Unix.FileMonitor.Hook/Library.cs
@@ -23,15 +23,15 @@ namespace CoreHook.Unix.FileMonitor.Hook
             ParameterValueConverter = new CamelCaseJsonValueConverter()
         };
 
-        Stack<String> Queue = new Stack<String>();
+        Queue<string> Queue = new Queue<string>();
 
         LocalHook OpenHook;
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall,
             CharSet = CharSet.Ansi,
             SetLastError = true)]
-        delegate Int32 DOpen(
-            String pathname, int flags, int mode);
+        delegate int DOpen(
+            string pathname, int flags, int mode);
 
         public Library(object InContext, string arg1)
         {
@@ -92,20 +92,20 @@ namespace CoreHook.Unix.FileMonitor.Hook
                 new DOpen(open_hook),
                 this);
 
-            OpenHook.ThreadACL.SetExclusiveACL(new Int32[] { 0 });
+            OpenHook.ThreadACL.SetExclusiveACL(new int[] { 0 });
         }
         const string LIBC = "libc";
         [DllImport(LIBC, SetLastError = true)]
-        internal static extern int open(String pathname, int flags, int mode);
+        internal static extern int open(string pathname, int flags, int mode);
 
-        static int open_hook(String pathname, int flags, int mode)
+        static int open_hook(string pathname, int flags, int mode)
         {
             Console.WriteLine($"Opening {pathname}...");
             Library This = (Library)HookRuntimeInfo.Callback;
 
             lock (This.Queue)
             {
-                This.Queue.Push(pathname);
+                This.Queue.Enqueue(pathname);
             }
             return open(pathname, flags, mode);
         }

--- a/Examples/Unix/CoreHook.Unix.FileMonitor/Program.cs
+++ b/Examples/Unix/CoreHook.Unix.FileMonitor/Program.cs
@@ -34,7 +34,7 @@ namespace CoreHook.Unix.FileMonitor
             string targetProgam = string.Empty;
             IsArchitectureArm();
             // Load the parameter
-            while ((args.Length != 1) || !Int32.TryParse(args[0], out TargetPID) || !File.Exists(args[0]))
+            while ((args.Length != 1) || !int.TryParse(args[0], out TargetPID) || !File.Exists(args[0]))
             {
                 if (TargetPID > 0)
                 {
@@ -50,7 +50,10 @@ namespace CoreHook.Unix.FileMonitor
 
                     args = new string[] { Console.ReadLine() };
 
-                    if (String.IsNullOrEmpty(args[0])) return;
+                    if (string.IsNullOrEmpty(args[0]))
+                    {
+                        return;
+                    }
                 }
                 else
                 {
@@ -162,9 +165,9 @@ namespace CoreHook.Unix.FileMonitor
         }
         private static void StartListener()
         {
-            var _listener = new NpListener(CoreHookPipeName);
-            _listener.RequestRetrieved += ClientConnectionMade;
-            _listener.Start();
+            var listener = new NpListener(CoreHookPipeName);
+            listener.RequestRetrieved += ClientConnectionMade;
+            listener.Start();
 
             Console.WriteLine("Press Enter to quit.");
             Console.ReadLine();


### PR DESCRIPTION
* Refactor code to switch from using types such String or Int32 to string and int.
* Use queues instead of stacks in hooking library examples