### PR TITLE
Assembly resolving fix

### DIFF
--- a/src/CoreHook.CoreLoad/Loader.cs
+++ b/src/CoreHook.CoreLoad/Loader.cs
@@ -43,21 +43,29 @@ namespace CoreHook.CoreLoad
         {
             if (paramPtr == null)
             {
+                Log("Invalid remote params");
+
                 throw new ArgumentNullException("Remote arguments parameter was null");
             }
 
             try
             {
+                Log($"Parsing params ptr {paramPtr}");
+
                 IntPtr remoteParams = (IntPtr)long.Parse(paramPtr, System.Globalization.NumberStyles.HexNumber);
+                Log($"Parsing remote params {remoteParams.ToInt32().ToString("X")}");
 
                 if (remoteParams == IntPtr.Zero)
                 {
                     throw new ArgumentOutOfRangeException("Remote arguments address was zero");
                 }
+                Log("Loading structure from remote params");
 
                 var connection = ConnectionData.LoadData(remoteParams);
+                Log($"Creating Resolver class from user library {connection.RemoteInfo.UserLibrary}");
 
                 var resolver = new Resolver(connection.RemoteInfo.UserLibrary);
+                Log($"Creating remote parameter array");
 
                 // Prepare parameter array.
                 var paramArray = new object[1 + connection.RemoteInfo.UserParams.Length];
@@ -67,14 +75,20 @@ namespace CoreHook.CoreLoad
                 paramArray[0] = connection.UnmanagedInfo;
                 for (int i = 0; i < connection.RemoteInfo.UserParams.Length; i++)
                     paramArray[i + 1] = connection.RemoteInfo.UserParams[i];
+                Log($"Loading user library {connection.RemoteInfo.UserLibrary}");
 
                 LoadUserLibrary(resolver.Assembly, paramArray, connection.RemoteInfo.ChannelName);
             }
             catch (Exception exception)
             {
-                Debug.WriteLine(exception.ToString());
+                Console.WriteLine(exception.ToString());
             }
             return 0;
+        }
+
+        private static void Log(string message)
+        {
+            Console.WriteLine(message);
         }
 
         private static bool IsUwp()

--- a/src/CoreHook.CoreLoad/Loader.cs
+++ b/src/CoreHook.CoreLoad/Loader.cs
@@ -71,9 +71,14 @@ namespace CoreHook.CoreLoad
             }
             catch (Exception exception)
             {
-                Console.WriteLine(exception.ToString());
+                Log(exception.ToString());
             }
             return 0;
+        }
+
+        private static void Log(string message)
+        {
+            Debug.WriteLine(message);
         }
 
         private static bool IsUwp()

--- a/src/CoreHook.CoreLoad/Loader.cs
+++ b/src/CoreHook.CoreLoad/Loader.cs
@@ -43,29 +43,20 @@ namespace CoreHook.CoreLoad
         {
             if (paramPtr == null)
             {
-                Log("Invalid remote params");
-
                 throw new ArgumentNullException("Remote arguments parameter was null");
             }
 
             try
             {
-                Log($"Parsing params ptr {paramPtr}");
-
                 IntPtr remoteParams = (IntPtr)long.Parse(paramPtr, System.Globalization.NumberStyles.HexNumber);
-                Log($"Parsing remote params {remoteParams.ToInt32().ToString("X")}");
 
                 if (remoteParams == IntPtr.Zero)
                 {
                     throw new ArgumentOutOfRangeException("Remote arguments address was zero");
                 }
-                Log("Loading structure from remote params");
-
                 var connection = ConnectionData.LoadData(remoteParams);
-                Log($"Creating Resolver class from user library {connection.RemoteInfo.UserLibrary}");
 
                 var resolver = new Resolver(connection.RemoteInfo.UserLibrary);
-                Log($"Creating remote parameter array");
 
                 // Prepare parameter array.
                 var paramArray = new object[1 + connection.RemoteInfo.UserParams.Length];
@@ -75,7 +66,6 @@ namespace CoreHook.CoreLoad
                 paramArray[0] = connection.UnmanagedInfo;
                 for (int i = 0; i < connection.RemoteInfo.UserParams.Length; i++)
                     paramArray[i + 1] = connection.RemoteInfo.UserParams[i];
-                Log($"Loading user library {connection.RemoteInfo.UserLibrary}");
 
                 LoadUserLibrary(resolver.Assembly, paramArray, connection.RemoteInfo.ChannelName);
             }
@@ -84,11 +74,6 @@ namespace CoreHook.CoreLoad
                 Console.WriteLine(exception.ToString());
             }
             return 0;
-        }
-
-        private static void Log(string message)
-        {
-            Console.WriteLine(message);
         }
 
         private static bool IsUwp()

--- a/src/CoreHook.CoreLoad/Resolver.cs
+++ b/src/CoreHook.CoreLoad/Resolver.cs
@@ -15,11 +15,14 @@ namespace CoreHook.CoreLoad
         private readonly ICompilationAssemblyResolver assemblyResolver;
         private readonly DependencyContext dependencyContext;
         private readonly AssemblyLoadContext loadContext;
+        private const string CoreHookModuleName = "CoreHook";
 
         public Resolver(string path)
         {
             try
             {
+                Log($"App base is {Path.GetDirectoryName(path)}");
+
                 Assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
 
                 dependencyContext = DependencyContext.Load(Assembly);
@@ -44,7 +47,7 @@ namespace CoreHook.CoreLoad
 
         private void Log(string message)
         {
-            Debug.WriteLine(message);
+            Console.WriteLine(message);
         }
 
         public Assembly Assembly { get; }
@@ -58,10 +61,13 @@ namespace CoreHook.CoreLoad
         {
             bool NamesMatchOrContain(RuntimeLibrary runtime)
             {
-                return string.Equals(runtime.Name, name.Name, StringComparison.OrdinalIgnoreCase)
-                    || runtime.Name.IndexOf(name.Name, StringComparison.OrdinalIgnoreCase) >= 0;
-            }
-     
+                bool matched = string.Equals(runtime.Name, name.Name, StringComparison.OrdinalIgnoreCase);
+                // if not matched by exact name or not the main defalt corehook module (which should be matched exactly)
+                if (!matched && !runtime.Name.Contains(CoreHookModuleName)){
+                    return runtime.Name.IndexOf(name.Name, StringComparison.OrdinalIgnoreCase) >= 0;
+                };
+                return matched;
+            }     
 
             Log($"OnResolving: {name}");
 

--- a/src/CoreHook.CoreLoad/Resolver.cs
+++ b/src/CoreHook.CoreLoad/Resolver.cs
@@ -15,13 +15,16 @@ namespace CoreHook.CoreLoad
         private readonly ICompilationAssemblyResolver assemblyResolver;
         private readonly DependencyContext dependencyContext;
         private readonly AssemblyLoadContext loadContext;
+
         private const string CoreHookModuleName = "CoreHook";
+
+        public Assembly Assembly { get; }
 
         public Resolver(string path)
         {
             try
             {
-                Log($"App base is {Path.GetDirectoryName(path)}");
+                Log($"Image base is {Path.GetDirectoryName(path)}");
 
                 Assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
 
@@ -47,10 +50,8 @@ namespace CoreHook.CoreLoad
 
         private void Log(string message)
         {
-            Console.WriteLine(message);
+            Debug.WriteLine(message);
         }
-
-        public Assembly Assembly { get; }
 
         public void Dispose()
         {

--- a/src/CoreHook.CoreLoad/Resolver.cs
+++ b/src/CoreHook.CoreLoad/Resolver.cs
@@ -24,7 +24,7 @@ namespace CoreHook.CoreLoad
         {
             try
             {
-                Log($"Image base is {Path.GetDirectoryName(path)}");
+                Log($"Image base path is {Path.GetDirectoryName(path)}");
 
                 Assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
 
@@ -48,22 +48,12 @@ namespace CoreHook.CoreLoad
             }
         }
 
-        private void Log(string message)
-        {
-            Debug.WriteLine(message);
-        }
-
-        public void Dispose()
-        {
-            loadContext.Resolving -= OnResolving;
-        }
-
         private Assembly OnResolving(AssemblyLoadContext context, AssemblyName name)
         {
             bool NamesMatchOrContain(RuntimeLibrary runtime)
             {
                 bool matched = string.Equals(runtime.Name, name.Name, StringComparison.OrdinalIgnoreCase);
-                // if not matched by exact name or not the main defalt corehook module (which should be matched exactly)
+                // if not matched by exact name or not a default corehook module (which should be matched exactly)
                 if (!matched && !runtime.Name.Contains(CoreHookModuleName)){
                     return runtime.Name.IndexOf(name.Name, StringComparison.OrdinalIgnoreCase) >= 0;
                 };
@@ -107,6 +97,16 @@ namespace CoreHook.CoreLoad
                 Log($"OnResolving error: {ex.ToString()}");
             }
             return null;
+        }
+
+        public void Dispose()
+        {
+            loadContext.Resolving -= OnResolving;
+        }
+
+        private void Log(string message)
+        {
+            Debug.WriteLine(message);
         }
     }
 }


### PR DESCRIPTION
Update assembly resolving code to handle default CoreHook assembly loading for when an application is published, such as the Win32 example on Windows 10 IoT Core. 