### PR TITLE
Refactor to use shared project for Examples

### DIFF
--- a/CoreHook.sln
+++ b/CoreHook.sln
@@ -63,7 +63,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreHook.Tests.SimpleHook1"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "target", "target", "{E601DB0A-91DB-45DD-928B-B9CF3BD65026}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreHook.Tests.TargetApp", "test\target\CoreHook.Tests.TargetApp\CoreHook.Tests.TargetApp.csproj", "{A3BAA2B1-64C9-42E1-BD46-F49AC4A4EF12}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreHook.Tests.TargetApp", "test\target\CoreHook.Tests.TargetApp\CoreHook.Tests.TargetApp.csproj", "{A3BAA2B1-64C9-42E1-BD46-F49AC4A4EF12}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{6F6AB2BD-CB01-4B87-88B0-BA00D15BD8D5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreHook.Examples.Common", "examples\Common\CoreHook.Examples.Common\CoreHook.Examples.Common.csproj", "{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -221,6 +225,14 @@ Global
 		{A3BAA2B1-64C9-42E1-BD46-F49AC4A4EF12}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A3BAA2B1-64C9-42E1-BD46-F49AC4A4EF12}.Release|x86.ActiveCfg = Release|Any CPU
 		{A3BAA2B1-64C9-42E1-BD46-F49AC4A4EF12}.Release|x86.Build.0 = Release|Any CPU
+		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Debug|x86.Build.0 = Debug|Any CPU
+		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Release|x86.ActiveCfg = Release|Any CPU
+		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -250,6 +262,8 @@ Global
 		{6210E5FC-5876-4A0C-AACE-12C1BB63CF5A} = {BFEBEA69-1024-42F8-A2D5-B1B43E6CE719}
 		{E601DB0A-91DB-45DD-928B-B9CF3BD65026} = {651578A4-4B76-4A11-897F-45A3D5714574}
 		{A3BAA2B1-64C9-42E1-BD46-F49AC4A4EF12} = {E601DB0A-91DB-45DD-928B-B9CF3BD65026}
+		{6F6AB2BD-CB01-4B87-88B0-BA00D15BD8D5} = {C1E373D4-037B-4479-9AF5-EE4E08642585}
+		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0} = {6F6AB2BD-CB01-4B87-88B0-BA00D15BD8D5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F1E6A8F-CBCB-4F01-B2C4-446C6F3AD674}

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # CoreHook
 
-A library that simplifies intercepting application function calls using managed code by [hosting](https://github.com/dotnet/docs/blob/master/docs/core/tutorials/netcore-hosting.md) the .NET Core runtime.
+A library that simplifies intercepting application function calls using managed code by [hosting](https://github.com/dotnet/docs/blob/master/docs/core/tutorials/netcore-hosting.md) the .NET Core runtime. 
 
-Inspired and based on the great [EasyHook](https://github.com/EasyHook/EasyHook).
+Inspired and based on the great [EasyHook](https://github.com/EasyHook/EasyHook). 
 
 ## Build status
 
-| Build server | Platform           | Build status                                                                                                                                 |
-| ------------ | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| AppVeyor     | Linux, Windows     | [![Build status](https://ci.appveyor.com/api/projects/status/kj3n6vwax0ds9k2k?svg=true)](https://ci.appveyor.com/project/unknownv2/corehook) |
-| Travis CI    | Linux              | [![Build Status](https://travis-ci.com/unknownv2/CoreHook.svg?branch=master)](https://travis-ci.com/unknownv2/CoreHook)                      |
+| Build server    | Platform           | Build status                                                                                                                                                                    |
+| --------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AppVeyor        | Linux, Windows     | [![Build status](https://ci.appveyor.com/api/projects/status/kj3n6vwax0ds9k2k?svg=true)](https://ci.appveyor.com/project/unknownv2/corehook)                                    |
+| Travis CI       | Linux              | [![Build Status](https://travis-ci.com/unknownv2/CoreHook.svg?branch=master)](https://travis-ci.com/unknownv2/CoreHook)                                                         |
+| Azure Pipelines | Linux              | [![Build Status](https://unknowndev.visualstudio.com/CoreHook/_apis/build/status/CoreHook/CoreHook)](https://unknowndev.visualstudio.com/CoreHook/_build/latest?definitionId=2) |
 
 
 ## Features
 * Intercept public API functions such as [kernel32.dll!CreateFile](https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-createfilew) on Windows or [libc!open](http://man7.org/linux/man-pages/man2/open.2.html) on Unix
 * Intercept internal functions by address or [name if symbol files are available](#windows-symbol-support)
 * Write libraries for intercepting API calls that can be ran on multiple architectures without any changes
+
+For more information, [see the wiki](https://github.com/unknownv2/CoreHook/wiki).
 
 ## Supported Platforms
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Inspired and based on the great [EasyHook](https://github.com/EasyHook/EasyHook)
 * Intercept internal functions by address or [name if symbol files are available](#windows-symbol-support)
 * Write libraries for intercepting API calls that can be ran on multiple architectures without any changes
 
+## Planned Features
+* Scripting API (compile and run scripts in a target process at runtime)
+* Memory Manager (such as reading, writing, and scanning)
+
 For more information, [see the wiki](https://github.com/unknownv2/CoreHook/wiki).
 
 ## Supported Platforms

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,12 @@
+pool:
+  vmImage: 'Ubuntu 16.04'
+  
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- script: |
+    dotnet build --configuration $(buildConfiguration)
+    dotnet publish --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY
+
+- task: PublishBuildArtifacts@1

--- a/examples/Common/CoreHook.Examples.Common/CoreHook.Examples.Common.csproj
+++ b/examples/Common/CoreHook.Examples.Common/CoreHook.Examples.Common.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>    
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\x64</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\x64</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CXuesong.JsonRpc.Streams" Version="0.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\CoreHook.IPC\CoreHook.IPC.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Common/CoreHook.Examples.Common/ISessionFeature.cs
+++ b/examples/Common/CoreHook.Examples.Common/ISessionFeature.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace CoreHook.Examples.Common
+{
+    public interface ISessionFeature
+    {
+        CancellationToken CancellationToken { get; }
+
+        void StopServer();
+    }
+}

--- a/examples/Common/CoreHook.Examples.Common/RpcService.cs
+++ b/examples/Common/CoreHook.Examples.Common/RpcService.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Linq;
+using System.IO;
+using System.IO.Pipes;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using CoreHook.IPC.NamedPipes;
+using CoreHook.IPC.Platform;
+using JsonRpc.Standard.Contracts;
+using JsonRpc.Standard.Server;
+using JsonRpc.Streams;
+
+namespace CoreHook.Examples.Common
+{
+    public class RpcService
+    {
+        private readonly ISessionFeature _session;
+        private readonly Type _service;
+        private string _pipeName;
+        private readonly Func<RequestContext, Func<Task>, Task> _handler;
+
+        public RpcService(ISessionFeature session, Type service, Func<RequestContext, Func<Task>, Task> handler)
+        {
+            _session = session;
+            _service = service;
+            _handler = handler;
+        }
+
+        public static RpcService CreateRpcService(
+            string namedPipeName, 
+            IPipePlatform pipePlatform, 
+            ISessionFeature session, Type rpcService,
+            Func<RequestContext, Func<Task>, Task> handler)
+        {
+            var service = new RpcService(session, rpcService, handler);
+
+            Task.Factory.StartNew(() => service.CreateServer(namedPipeName, pipePlatform),
+                TaskCreationOptions.LongRunning);
+
+            return service;
+        }
+
+        private static readonly IJsonRpcContractResolver myContractResolver = new JsonRpcContractResolver
+        {
+            // Use camelcase for RPC method names.
+            NamingStrategy = new CamelCaseJsonRpcNamingStrategy(),
+            // Use camelcase for the property names in parameter value objects
+            ParameterValueConverter = new CamelCaseJsonValueConverter()
+        };
+
+        private INamedPipeServer CreateServer(string namedPipeName, IPipePlatform pipePlatform)
+        {
+            _pipeName = namedPipeName;
+            return NamedPipeServer.StartNewServer(namedPipeName, pipePlatform, HandleConnection);
+        }
+
+        public IJsonRpcServiceHost BuildServiceHost(Type service)
+        {
+            var builder = new JsonRpcServiceHostBuilder
+            {
+                ContractResolver = myContractResolver,
+            };
+
+            builder.Register(service);
+
+            builder.Intercept(_handler);
+
+            return builder.Build();
+        }
+
+        public void HandleConnection(IPC.IConnection connection)
+        {
+            Console.WriteLine($"Connection received from pipe {_pipeName}");
+
+            var pipeServer = connection.ServerStream;
+
+            IJsonRpcServiceHost host = BuildServiceHost(_service);
+
+            var serverHandler = new StreamRpcServerHandler(host);
+
+            serverHandler.DefaultFeatures.Set(_session);
+
+            using (var reader = new ByLineTextMessageReader(pipeServer))
+            using (var writer = new ByLineTextMessageWriter(pipeServer))
+            using (serverHandler.Attach(reader, writer))
+            {
+                // Wait for exit
+                _session.CancellationToken.WaitHandle.WaitOne();
+            }
+        }
+    }
+}

--- a/examples/UWP/CoreHook.UWP.FileMonitor/Program.cs
+++ b/examples/UWP/CoreHook.UWP.FileMonitor/Program.cs
@@ -181,8 +181,6 @@ namespace CoreHook.UWP.FileMonitor
                 CoreHookPipeName);
         }
 
-        private static FileMonitorSessionFeature session = new FileMonitorSessionFeature();
-
         private static void StartListener()
         {
             var session = new FileMonitorSessionFeature();

--- a/examples/UWP/CoreHook.UWP.FileMonitor/Program.cs
+++ b/examples/UWP/CoreHook.UWP.FileMonitor/Program.cs
@@ -31,7 +31,7 @@ namespace CoreHook.UWP.FileMonitor
         private const string HookLibraryDirName = "Hook";
         private const string HookLibraryName = "CoreHook.UWP.FileMonitor.Hook.dll";
 
-        private static IPC.Platform.IPipePlatform pipePlatform = new Pipe.PipePlatform();
+        private static IPipePlatform pipePlatform = new Pipe.PipePlatform();
 
         private static bool IsArchitectureArm()
         {
@@ -206,7 +206,7 @@ namespace CoreHook.UWP.FileMonitor
             session.StopServer();
         }
 
-        public static INamedPipeServer CreateServer(string namedPipeName, IPipePlatform pipePlatform)
+        private static INamedPipeServer CreateServer(string namedPipeName, IPipePlatform pipePlatform)
         {
             return NamedPipeServer.StartNewServer(namedPipeName, pipePlatform, HandleConnection);
         }

--- a/examples/Win32/CoreHook.FileMonitor.Service/CoreHook.FileMonitor.Service.csproj
+++ b/examples/Win32/CoreHook.FileMonitor.Service/CoreHook.FileMonitor.Service.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\CoreHook.IPC\CoreHook.IPC.csproj" />
+    <ProjectReference Include="..\..\Common\CoreHook.Examples.Common\CoreHook.Examples.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/Win32/CoreHook.FileMonitor.Service/FileMonitorSessionFeature.cs
+++ b/examples/Win32/CoreHook.FileMonitor.Service/FileMonitorSessionFeature.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace CoreHook.FileMonitor.Service
 {
-    public class FileMonitorSessionFeature
+    public class FileMonitorSessionFeature : Examples.Common.ISessionFeature
     {
         private readonly CancellationTokenSource cts = new CancellationTokenSource();
 

--- a/examples/Win32/CoreHook.FileMonitor/CoreHook.FileMonitor.csproj
+++ b/examples/Win32/CoreHook.FileMonitor/CoreHook.FileMonitor.csproj
@@ -12,13 +12,11 @@
     <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\x64</OutputPath>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <WarningsAsErrors />
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
     <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\x86</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Prefer32Bit>true</Prefer32Bit>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
@@ -27,13 +25,11 @@
     <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\x64</OutputPath>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <WarningsAsErrors />    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\x86</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Prefer32Bit>true</Prefer32Bit>
     <PlatformTarget>x86</PlatformTarget>    
   </PropertyGroup>

--- a/examples/Win32/CoreHook.FileMonitor/Program.cs
+++ b/examples/Win32/CoreHook.FileMonitor/Program.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using CoreHook.FileMonitor.Service;
 using CoreHook.IPC.NamedPipes;
 using CoreHook.IPC.Platform;
@@ -269,7 +270,7 @@ namespace CoreHook.FileMonitor
 
         private static void StartListener()
         {
-            CreateServer(CoreHookPipeName, pipePlatform);
+            Task.Factory.StartNew(() => CreateServer(CoreHookPipeName, pipePlatform), TaskCreationOptions.LongRunning);
 
             Console.WriteLine("Press Enter to quit.");
             Console.ReadLine();

--- a/examples/Win32/CoreHook.FileMonitor/Program.cs
+++ b/examples/Win32/CoreHook.FileMonitor/Program.cs
@@ -6,13 +6,11 @@ using CoreHook.FileMonitor.Service;
 using CoreHook.IPC.Platform;
 using CoreHook.ManagedHook.Remote;
 using CoreHook.ManagedHook.ProcessUtils;
-using CoreHook.Examples.Common;
 
 namespace CoreHook.FileMonitor
 {
     class Program
     {
-
         private const string CoreHookPipeName = "CoreHook";
         private const string HookLibraryDirName = "Hook";
         private const string HookLibraryName = "CoreHook.FileMonitor.Hook.dll";
@@ -259,7 +257,7 @@ namespace CoreHook.FileMonitor
         {
             var session = new FileMonitorSessionFeature();
 
-            RpcService.CreateRpcService(
+            Examples.Common.RpcService.CreateRpcService(
                   CoreHookPipeName,
                   pipePlatform,
                   session,

--- a/examples/Win32/CoreHook.FileMonitor/Program.cs
+++ b/examples/Win32/CoreHook.FileMonitor/Program.cs
@@ -187,6 +187,7 @@ namespace CoreHook.FileMonitor
 
             return true;
         }
+
         /// <summary>
         /// Check if a file path is valid, otherwise throw an exception
         /// </summary>
@@ -202,6 +203,7 @@ namespace CoreHook.FileMonitor
                 throw new FileNotFoundException($"File path {filePath} does not exist");
             }
         }
+
         private static void CreateAndInjectDll(string exePath, string injectionLibrary, string coreHookDll)
         {
             ValidateFilePath(exePath);
@@ -235,6 +237,7 @@ namespace CoreHook.FileMonitor
                      CoreHookPipeName);
             }
         }
+
         private static void InjectDllIntoTarget(int procId, string injectionLibrary, string coreHookDll)
         {
             ValidateFilePath(injectionLibrary);
@@ -274,7 +277,7 @@ namespace CoreHook.FileMonitor
             session.StopServer();
         }
 
-        public static INamedPipeServer CreateServer(string namedPipeName, IPipePlatform pipePlatform)
+        private static INamedPipeServer CreateServer(string namedPipeName, IPipePlatform pipePlatform)
         {
             return NamedPipeServer.StartNewServer(namedPipeName, pipePlatform, HandleConnection);
         }

--- a/examples/Win32/CoreHook.FileMonitor/Program.cs
+++ b/examples/Win32/CoreHook.FileMonitor/Program.cs
@@ -259,8 +259,10 @@ namespace CoreHook.FileMonitor
                     },
                     new PipePlatform(),
                     CoreHookPipeName);
-            }        
+            }
         }
+
+        private static FileMonitorSessionFeature session = new FileMonitorSessionFeature();
 
         private static void StartListener()
         {
@@ -268,6 +270,8 @@ namespace CoreHook.FileMonitor
 
             Console.WriteLine("Press Enter to quit.");
             Console.ReadLine();
+
+            session.StopServer();
         }
 
         public static INamedPipeServer CreateServer(string namedPipeName, IPipePlatform pipePlatform)
@@ -285,7 +289,6 @@ namespace CoreHook.FileMonitor
 
             var serverHandler = new StreamRpcServerHandler(host);
 
-            var session = new FileMonitorSessionFeature();
             serverHandler.DefaultFeatures.Set(session);
 
             using (var reader = new ByLineTextMessageReader(pipeServer))

--- a/src/CoreHook.IPC/IConnection.cs
+++ b/src/CoreHook.IPC/IConnection.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CoreHook.IPC
+{
+    public interface IConnection
+    {
+        bool IsConnected { get; }
+        string ReadRequest();
+        bool TrySendResponse(string message);
+    }
+}

--- a/src/CoreHook.IPC/IConnection.cs
+++ b/src/CoreHook.IPC/IConnection.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.IO.Pipes;
 
 namespace CoreHook.IPC
 {
     public interface IConnection
     {
+        NamedPipeServerStream ServerStream { get; }
         bool IsConnected { get; }
+
         string ReadRequest();
         bool TrySendResponse(string message);
     }

--- a/src/CoreHook.IPC/NamedPipes/INamedPipeClient.cs
+++ b/src/CoreHook.IPC/NamedPipes/INamedPipeClient.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CoreHook.IPC.NamedPipes
+{
+    public interface INamedPipeClient : IDisposable
+    {
+        bool Connect(int timeOutMilliseconds);
+        void SendRequest(string request);
+        string ReadRawResponse();
+    }
+}

--- a/src/CoreHook.IPC/NamedPipes/INamedPipeServer.cs
+++ b/src/CoreHook.IPC/NamedPipes/INamedPipeServer.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CoreHook.IPC.NamedPipes
+{
+    public interface INamedPipeServer : IDisposable
+    {
+        
+    }
+}

--- a/src/CoreHook.IPC/NamedPipes/NamedPipeClient.cs
+++ b/src/CoreHook.IPC/NamedPipes/NamedPipeClient.cs
@@ -5,7 +5,7 @@ using System.Security.Principal;
 
 namespace CoreHook.IPC.NamedPipes
 {
-    public class NamedPipeClient : IDisposable
+    public class NamedPipeClient : INamedPipeClient
     {
         private string pipeName;
         private NamedPipeClientStream clientStream;

--- a/src/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
+++ b/src/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
@@ -6,7 +6,7 @@ using CoreHook.IPC.Platform;
 
 namespace CoreHook.IPC.NamedPipes
 {
-    public class NamedPipeServer : IDisposable
+    public class NamedPipeServer : INamedPipeServer
     {
         private const int MaxPipeNameLength = 250;
         private bool isStopping;

--- a/src/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
+++ b/src/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
@@ -34,6 +34,17 @@ namespace CoreHook.IPC.NamedPipes
             return pipeServer;
         }
 
+        public static INamedPipeServer StartNewServer(string pipeName, IPipePlatform platform, Action<IConnection> handleConnection)
+        {
+            if (pipeName.Length > MaxPipeNameLength)
+            {
+                throw new PipeMessageLengthException(pipeName, MaxPipeNameLength);
+            }
+            var pipeServer = new NamedPipeServer(pipeName, platform, connection => handleConnection(connection));
+            pipeServer.OpenListeningPipe();
+            return pipeServer;
+        }
+
         public void Dispose()
         {
             isStopping = true;

--- a/src/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
+++ b/src/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
@@ -15,7 +15,7 @@ namespace CoreHook.IPC.NamedPipes
         private IPipePlatform platform;
         private NamedPipeServerStream listeningPipe;
 
-        private NamedPipeServer(string pipeName, IPipePlatform platform, Action<Connection> handleConnection)
+        private NamedPipeServer(string pipeName, IPipePlatform platform, Action<IConnection> handleConnection)
         {
             this.pipeName = pipeName;
             this.platform = platform;
@@ -23,7 +23,7 @@ namespace CoreHook.IPC.NamedPipes
             this.isStopping = false;
         }
 
-        public static NamedPipeServer StartNewServer(string pipeName, IPipePlatform platform, Action<string, Connection> handleRequest)
+        public static INamedPipeServer StartNewServer(string pipeName, IPipePlatform platform, Action<string, IConnection> handleRequest)
         {
             if (pipeName.Length > MaxPipeNameLength)
             {
@@ -44,7 +44,7 @@ namespace CoreHook.IPC.NamedPipes
             }
         }
 
-        private static void HandleConnection(Connection connection, Action<string, Connection> handleRequest)
+        private static void HandleConnection(IConnection connection, Action<string, IConnection> handleRequest)
         {
             while (connection.IsConnected)
             {
@@ -143,7 +143,7 @@ namespace CoreHook.IPC.NamedPipes
             Console.WriteLine(e);
         }
 
-        public class Connection
+        public class Connection : IConnection
         {
             private NamedPipeServerStream serverStream;
             private StreamReader reader;

--- a/src/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
+++ b/src/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
@@ -36,8 +36,8 @@ namespace CoreHook.IPC.NamedPipes
 
         public void Dispose()
         {
-            this.isStopping = true;
-            NamedPipeServerStream pipe = Interlocked.Exchange(ref this.listeningPipe, null);
+            isStopping = true;
+            NamedPipeServerStream pipe = Interlocked.Exchange(ref listeningPipe, null);
             if (pipe != null)
             {
                 pipe.Dispose();
@@ -49,8 +49,7 @@ namespace CoreHook.IPC.NamedPipes
             while (connection.IsConnected)
             {
                 string request = connection.ReadRequest();
-                if (request == null ||
-                    !connection.IsConnected)
+                if (request == null || !connection.IsConnected)
                 {
                     break;
                 }
@@ -77,7 +76,7 @@ namespace CoreHook.IPC.NamedPipes
 
         private void OnNewConnection(IAsyncResult ar)
         {
-            this.OnNewConnection(ar, createNewThreadIfSynchronous: true);
+            OnNewConnection(ar, createNewThreadIfSynchronous: true);
         }
 
         private void OnNewConnection(IAsyncResult ar, bool createNewThreadIfSynchronous)
@@ -122,7 +121,7 @@ namespace CoreHook.IPC.NamedPipes
                     {
                         try
                         {
-                            handleConnection(new Connection(pipe, () => this.isStopping));
+                            handleConnection(new Connection(pipe, () => isStopping));
                         }
                         catch (Exception e)
                         {

--- a/src/CoreHook.ManagedHook/Remote/InjectionLoader.cs
+++ b/src/CoreHook.ManagedHook/Remote/InjectionLoader.cs
@@ -67,7 +67,9 @@ namespace CoreHook.ManagedHook.Remote
             lock (InjectionList)
             {
                 if (!InjectionList.ContainsKey(InTargetPID))
+                {
                     InjectionList.Add(InTargetPID, WaitInfo);
+                }
             }
         }
 

--- a/src/CoreHook.ManagedHook/Remote/InjectionLoader.cs
+++ b/src/CoreHook.ManagedHook/Remote/InjectionLoader.cs
@@ -15,12 +15,12 @@ namespace CoreHook.ManagedHook.Remote
             public Exception Error = null;
         }
 
-        public static NamedPipeServer CreateServer(string namedPipeName, IPipePlatform pipePlatform)
+        public static INamedPipeServer CreateServer(string namedPipeName, IPipePlatform pipePlatform)
         {
             return NamedPipeServer.StartNewServer(namedPipeName, pipePlatform, HandleRequest);
         }
 
-        private static void HandleRequest(string request, NamedPipeServer.Connection connection)
+        private static void HandleRequest(string request, IPC.IConnection connection)
         {
             var message = NamedPipeMessages.Message.FromString(request);
 

--- a/src/CoreHook.ManagedHook/Remote/InjectionLoader.cs
+++ b/src/CoreHook.ManagedHook/Remote/InjectionLoader.cs
@@ -43,7 +43,6 @@ namespace CoreHook.ManagedHook.Remote
             }
         }
 
-
         private static SortedList<int, InjectionWait> InjectionList = new SortedList<int, InjectionWait>();
 
         public static void BeginInjection(int InTargetPID)
@@ -101,9 +100,7 @@ namespace CoreHook.ManagedHook.Remote
                 throw waitInfo.Error;
         }
 
-        public static void InjectionException(
-            int clientPID,
-            Exception e)
+        public static void InjectionException(int clientPID, Exception e)
         {
             InjectionWait waitInfo;
 

--- a/src/CoreHook.ManagedHook/Remote/RemoteHookingConfig.cs
+++ b/src/CoreHook.ManagedHook/Remote/RemoteHookingConfig.cs
@@ -6,21 +6,64 @@ namespace CoreHook.ManagedHook.Remote
 {
     public class ProcessCreationConfig : ICreateProcessConfig
     {
+        /// <summary>
+        /// Filepath to an executable program on the system that is to be launched.
+        /// </summary>
         public string ExecutablePath { get; set; }
+        /// <summary>
+        /// Arguments to be passed to the executable program when it is started
+        /// </summary>
         public string CommandLine { get; set; }
+        /// <summary>
+        /// Attributes and options passed to the process creation function call.
+        /// </summary>
         public uint ProcessCreationFlags { get; set; }
     }
     public class RemoteHookingConfig : ICoreHookConfig, ICoreRunConfig, ICoreLoadConfig
-    {   
+    {
+        /// <summary>
+        /// Library that implements function intercept exports for the LocalHook class
+        /// such as DetourInstallHook.
+        /// </summary>
         public string DetourLibrary { get; set; }
-        public string PayloadLibrary { get; set;  }
+        /// <summary>
+        /// .NET library that is loaded and executed inside the target process
+        /// by the boostrap library after starting the .NET Core runtime.
+        /// </summary>
+        public string PayloadLibrary { get; set; }
+        /// <summary>
+        /// Library that initializes the .NET Core runtime (CoreCLR) and allows
+        /// loading and executing .NET Assemblies.
+        /// </summary>
         public string HostLibrary { get; set; }
+        /// <summary>
+        /// Option to enable the logging module inside the HostLibrary.
+        /// </summary>
         public bool VerboseLog { get; set; }
+        /// <summary>
+        /// Option to enable waiting for a debugger to attach before any 
+        /// .NET Assemblies are loaded by the HostLibrary.
+        /// </summary>
         public bool WaitForDebugger { get; set; }
+        /// <summary>
+        /// Option to immediately execute an .NET Assembly after initializing
+        /// the .NET Core runtime.
+        /// </summary>
         public bool StartAssembly { get; set; }
-
+        /// <summary>
+        /// Library that resolves dependencies and passes arguments to
+        /// the .NET payload Assembly.
+        /// </summary>
         public string CLRBootstrapLibrary { get; set; }
+        /// <summary>
+        /// Directory path which contains the main CoreCLR modules for hosting the runtime
+        /// such as CoreCLR and clrjit libraries.
+        /// </summary>
         public string CoreCLRPath { get; set; }
+        /// <summary>
+        /// Directory path which contains the CoreCLR Assembly reference
+        /// runtime libraries such as System.Private.CoreLib.dll.
+        /// </summary>
         public string CoreCLRLibrariesPath { get; set; }
     }
     public interface ICreateProcessConfig

--- a/test/CoreHook.Tests/NamedPipeTest.cs
+++ b/test/CoreHook.Tests/NamedPipeTest.cs
@@ -63,6 +63,34 @@ namespace CoreHook.Tests
         }
 
         [Fact]
+        private void ShouldConnectToServerAndReceiveRandomResponse()
+        {
+            const string namedPipe = "NamedPipeNameTest3";
+            const string testMessage = "TestMessage";
+            bool receivedCorrectMessage = false;
+
+            using (var pipeServer = CreateServer(namedPipe, new PipePlatformBase(),
+                (string request, IPC.IConnection connection) =>
+                {
+                    if (request == testMessage)
+                    {
+                        receivedCorrectMessage = true;
+                    }
+                    connection.TrySendResponse("RandomResponse");
+                }))
+            {
+                using (INamedPipeClient pipeClient = new NamedPipeClient(namedPipe))
+                {
+                    if (SendPipeMessage(pipeClient, testMessage))
+                    {
+                        Assert.NotEqual(pipeClient.ReadRawResponse(), testMessage);
+                    }
+                }
+            }
+            Assert.True(receivedCorrectMessage);
+        }
+
+        [Fact]
         private void ShouldNotConnectToServer()
         {
             const string clientNamedPipe = "ClientNamedPipeNameTest1";

--- a/test/CoreHook.Tests/NamedPipeTest.cs
+++ b/test/CoreHook.Tests/NamedPipeTest.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using CoreHook.IPC.NamedPipes;
+using CoreHook.IPC.Platform;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Xunit;
@@ -7,5 +9,48 @@ namespace CoreHook.Tests
 {
     public class NamedPipeTest
     {
+        private const string NamedPipeName = "NamedPipeNameTest";
+
+        [Fact]
+        private void ShouldConnectToServer()
+        {
+            bool receivedMessage = false;
+            const string testMessage = "TestMessage";
+
+            using (var pipeServer = CreateServer(NamedPipeName, new PipePlatformBase(),
+                (string request, NamedPipeServer.Connection connection) =>
+                {
+                    if (request == testMessage)
+                    {
+                        receivedMessage = true;
+                    }
+                    connection.TrySendResponse(request);
+                }))
+            {
+                using (INamedPipeClient pipeClient = new NamedPipeClient(NamedPipeName))
+                {
+                    if(SendPipeMessage(pipeClient, testMessage))
+                    {
+                        Assert.Equal(pipeClient.ReadRawResponse(), testMessage);
+                    }
+                }
+            }
+            Assert.True(receivedMessage);
+        }
+
+        private static INamedPipeServer CreateServer(string namedPipeName, IPipePlatform pipePlatform, Action<string, NamedPipeServer.Connection> handleRequest)
+        {
+            return NamedPipeServer.StartNewServer(namedPipeName, pipePlatform, handleRequest);
+        }
+
+        private static bool SendPipeMessage(INamedPipeClient pipeClient, string message)
+        {
+            if (pipeClient.Connect(3000))
+            {
+                pipeClient.SendRequest(message);
+                return true;
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
* Start work on converting examples projects to use a shared class to reduce code resuse.
* Add more NamedPipe tests to help with refactoring