### PR TITLE
Fix empty string check in Linux binary loader

### DIFF
--- a/src/CoreHook.BinaryInjection/BinaryLoader/Linux/LinuxBinaryLoader.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/Linux/LinuxBinaryLoader.cs
@@ -319,7 +319,7 @@ namespace CoreHook.BinaryInjection
             {
                 foreach (var binary in dependencies)
                 {
-                    if (string.IsNullOrEmpty(binary))
+                    if (!string.IsNullOrEmpty(binary))
                     {
                         var libName = Path.Combine(dir, binary);
                         if (!File.Exists(libName))


### PR DESCRIPTION
Fix empty string check since for Linux the corehook detours module is loaded from `/usr/lib` (after being installed there) and we do not need to inject it.