### PR TITLE
Remove native corehook dll DetourWaitForPendingRemovals call

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Inspired and based on the great [EasyHook](https://github.com/EasyHook/EasyHook)
 * Intercept internal functions by address or [name if symbol files are available](#windows-symbol-support)
 * Write libraries for intercepting API calls that can be ran on multiple architectures without any changes
 
-## Planned Features
-* Scripting API (compile and run scripts in a target process at runtime)
-* Memory Manager (such as reading, writing, and scanning)
-
 For more information, [see the wiki](https://github.com/unknownv2/CoreHook/wiki).
 
 ## Supported Platforms

--- a/src/CoreHook/Hook/LocalHook.cs
+++ b/src/CoreHook/Hook/LocalHook.cs
@@ -425,7 +425,7 @@ namespace CoreHook
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            NativeAPI.DetourWaitForPendingRemovals();
+            //NativeAPI.DetourWaitForPendingRemovals();
         }
     }
 }


### PR DESCRIPTION
The API is not implemented at this time, so it will be enabled again once it is implemented in the native corehook.dll module