### PR TITLE
Refactor: Clean up Process Management and Injection

### DIFF
--- a/src/CoreHook.BinaryInjection/BinaryLoader/IBinaryLoader.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/IBinaryLoader.cs
@@ -20,7 +20,7 @@ namespace CoreHook.BinaryInjection
         IntPtr CopyMemoryTo(
             Process proc,
             byte[] buffer,
-            uint length);
+            int length);
     }
     public interface IFunctionName
     {

--- a/src/CoreHook.BinaryInjection/BinaryLoader/Windows/WindowsBinaryLoader.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/Windows/WindowsBinaryLoader.cs
@@ -15,7 +15,7 @@ namespace CoreHook.BinaryInjection
         {
             _memoryManager = memoryManager;
             _processManager = processManager;
-            _memoryManager.FreeMemory += (proc, address, length) => processManager.FreeMemory(address, 0);
+            _memoryManager.FreeMemory += (proc, address, length) => processManager.FreeMemory(address);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace CoreHook.BinaryInjection
                 call.FunctionName, 
                 new FunctionCallArgs(call.ManagedFunction, call.Arguments));
 
-        public IntPtr CopyMemoryTo(Process proc, byte[] buffer, uint length) 
+        public IntPtr CopyMemoryTo(Process proc, byte[] buffer, int length) 
             => _memoryManager.Add(proc, _processManager.MemCopyTo(buffer, length), false);
 
         public void Load(

--- a/src/CoreHook.BinaryInjection/Host/RemoteFunctionArgs.cs
+++ b/src/CoreHook.BinaryInjection/Host/RemoteFunctionArgs.cs
@@ -19,7 +19,7 @@ namespace CoreHook.BinaryInjection
     {
         public bool Is64BitProcess;
         public IntPtr UserData;
-        public uint UserDataSize;
+        public int UserDataSize;
         public byte[] Serialize()
         {
             using (var ms = new MemoryStream())

--- a/src/CoreHook.ManagedHook/Remote/RemoteHooking.cs
+++ b/src/CoreHook.ManagedHook/Remote/RemoteHooking.cs
@@ -255,7 +255,7 @@ namespace CoreHook.ManagedHook.Remote
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine(ex.ToString());
+                            Debug.WriteLine(ex.ToString());
                         }
                     }
                 }

--- a/src/CoreHook.ManagedHook/Remote/RemoteHooking.cs
+++ b/src/CoreHook.ManagedHook/Remote/RemoteHooking.cs
@@ -212,7 +212,7 @@ namespace CoreHook.ManagedHook.Remote
                     try
                     {
                         var process = ProcessHelper.GetProcessById(targetPID);
-                        var length = (uint)passThruStream.Length;
+                        var length = (int)passThruStream.Length;
 
                         using (var binaryLoader = GetBinaryLoader(process))
                         {

--- a/src/CoreHook.Unmanaged/IProcessManager.cs
+++ b/src/CoreHook.Unmanaged/IProcessManager.cs
@@ -8,7 +8,7 @@ namespace CoreHook.Unmanaged
         void InjectBinary(string modulePath);
         IntPtr Execute(string module, string function, byte[] args, bool canWait = true);
         void OpenHandle(Process process);
-        bool FreeMemory(IntPtr address, int size = 0);
-        IntPtr MemCopyTo(byte[] data, uint size = 0);
+        bool FreeMemory(IntPtr address, int? size = null);
+        IntPtr MemCopyTo(byte[] data, int? size = null);
     }
 }

--- a/src/CoreHook.Unmanaged/NativeMethods.Windows.cs
+++ b/src/CoreHook.Unmanaged/NativeMethods.Windows.cs
@@ -57,7 +57,7 @@ namespace CoreHook.Unmanaged
         internal static extern IntPtr VirtualAllocEx(
             SafeProcessHandle hProcess, 
             IntPtr lpAddress, 
-            uint dwSize, 
+            int dwSize, 
             AllocationType flAllocationType, 
             MemoryProtection flProtect);
 
@@ -86,7 +86,7 @@ namespace CoreHook.Unmanaged
             SafeProcessHandle hProcess, 
             IntPtr lpBaseAddress, 
             byte[] lpBuffer, 
-            uint nSize, 
+            int nSize, 
             out UIntPtr lpNumberOfBytesWritten);
 
         [DllImport("kernel32.dll")]


### PR DESCRIPTION
* Add comments to RemoteHooking class to improve code readability.
* Use integers with nullable types instead of unsigned integers native memory allocations.
* Remove unused memory allocation in the RemoteHooking class, in the PrepareInjection method while serializing the remote info class passed to the process and CoreLoad