### PR TITLE
Refactor the Windows Process Manager class

### DIFF
--- a/examples/Uwp/CoreHook.Uwp.FileMonitor/Program.cs
+++ b/examples/Uwp/CoreHook.Uwp.FileMonitor/Program.cs
@@ -5,7 +5,6 @@ using System.IO.Pipes;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using CoreHook.FileMonitor.Service;
 using CoreHook.IPC.Platform;
 using CoreHook.ManagedHook.Remote;
@@ -31,7 +30,7 @@ namespace CoreHook.Uwp.FileMonitor
         private const string HookLibraryName = "CoreHook.Uwp.FileMonitor.Hook.dll";
         /// <summary>
         /// The name of the pipe used for notifying the host process
-        /// if hooking plugin has been loaded succesfully loaded in
+        /// if the hooking plugin has been loaded succesfully loaded in
         /// the target process or not. 
         /// </summary>
         private const string InjectionPipeName = "UwpCoreHookInjection";
@@ -50,11 +49,6 @@ namespace CoreHook.Uwp.FileMonitor
 
         private static void Main(string[] args)
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                throw new PlatformNotSupportedException("UWP example");
-            }
-
             int targetPID = 0;
             string targetApp = string.Empty;
 

--- a/examples/Win32/CoreHook.FileMonitor/Program.cs
+++ b/examples/Win32/CoreHook.FileMonitor/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using CoreHook.FileMonitor.Service;
 using CoreHook.IPC.Platform;
 using CoreHook.ManagedHook.ProcessUtils;
@@ -27,7 +26,7 @@ namespace CoreHook.FileMonitor
         private const string HookLibraryName = "CoreHook.FileMonitor.Hook.dll";
         /// <summary>
         /// The name of the pipe used for notifying the host process
-        /// if hooking plugin has been loaded succesfully loaded in
+        /// if the hooking plugin has been loaded succesfully loaded in
         /// the target process or not. 
         /// </summary>
         private const string InjectionPipeName = "CoreHookInjection";
@@ -46,11 +45,6 @@ namespace CoreHook.FileMonitor
 
         private static void Main(string[] args)
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                throw new PlatformNotSupportedException("Win32 example");
-            }
-
             int targetPID = 0;
             string targetProgam = string.Empty;
 

--- a/src/CoreHook.ManagedHook/Remote/RemoteHooking.cs
+++ b/src/CoreHook.ManagedHook/Remote/RemoteHooking.cs
@@ -12,6 +12,7 @@ using CoreHook.BinaryInjection.Host;
 using CoreHook.CoreLoad;
 using CoreHook.IPC.Platform;
 using CoreHook.Memory;
+using CoreHook.Memory.Processes;
 using static CoreHook.ManagedHook.ProcessUtils.ProcessHelper;
 
 namespace CoreHook.ManagedHook.Remote
@@ -39,7 +40,7 @@ namespace CoreHook.ManagedHook.Remote
             {
                 return new BinaryLoader(
                     new MemoryManager(),
-                    new Memory.Windows.ProcessManager(process));
+                    new ProcessManager(process));
             }
             else
             {
@@ -223,11 +224,11 @@ namespace CoreHook.ManagedHook.Remote
                             using (var binaryLoader = GetBinaryLoader(process))
                             {
                                 binaryLoader.Load(process, remoteHookConfig.HostLibrary, new[] { remoteHookConfig.DetourLibrary });
-
+                                var binaryLoaderConfig = GetBinaryLoaderConfig();
                                 binaryLoader.ExecuteRemoteFunction(process,
                                     new RemoteFunctionCall
                                     {
-                                        Arguments = new BinaryLoaderSerializer(GetBinaryLoaderConfig())
+                                        Arguments = new BinaryLoaderSerializer(binaryLoaderConfig)
                                         {
                                             Arguments = new BinaryLoaderArguments
                                             {

--- a/src/CoreHook.ManagedHook/Remote/RemoteHooking.cs
+++ b/src/CoreHook.ManagedHook/Remote/RemoteHooking.cs
@@ -224,11 +224,10 @@ namespace CoreHook.ManagedHook.Remote
                             using (var binaryLoader = GetBinaryLoader(process))
                             {
                                 binaryLoader.Load(process, remoteHookConfig.HostLibrary, new[] { remoteHookConfig.DetourLibrary });
-                                var binaryLoaderConfig = GetBinaryLoaderConfig();
                                 binaryLoader.ExecuteRemoteFunction(process,
                                     new RemoteFunctionCall
                                     {
-                                        Arguments = new BinaryLoaderSerializer(binaryLoaderConfig)
+                                        Arguments = new BinaryLoaderSerializer(GetBinaryLoaderConfig())
                                         {
                                             Arguments = new BinaryLoaderArguments
                                             {

--- a/src/CoreHook.Memory/MemoryHelper.cs
+++ b/src/CoreHook.Memory/MemoryHelper.cs
@@ -4,9 +4,9 @@ using System.ComponentModel;
 
 namespace CoreHook.Memory
 {
-    public class MemoryHelper
+    internal class MemoryHelper
     {
-        public static IntPtr Allocate(IntPtr address, int size, AllocationType allocationFlags = AllocationType.Commit, MemoryProtection protectionFlags = MemoryProtection.ExecuteReadWrite)
+        internal static IntPtr Allocate(IntPtr address, int size, AllocationType allocationFlags = AllocationType.Commit, MemoryProtection protectionFlags = MemoryProtection.ExecuteReadWrite)
         {
             // Allocate a memory page
             var ret = VirtualAlloc(address, (uint)size, allocationFlags, protectionFlags);
@@ -18,7 +18,7 @@ namespace CoreHook.Memory
             // If the pointer isn't valid, throws an exception
             throw new Win32Exception(string.Format("Couldn't allocate memory of {0} byte(s).", size));
         }
-        public static void Free(IntPtr address, int size = 0, FreeType freeType = FreeType.Release)
+        internal static void Free(IntPtr address, int size = 0, FreeType freeType = FreeType.Release)
         {
             // Free the memory
             if (!VirtualFree(address, size, freeType))
@@ -27,7 +27,7 @@ namespace CoreHook.Memory
                 throw new Win32Exception(string.Format("The memory page 0x{0} cannot be freed.", address.ToString("X")));
             }
         }
-        public static bool ChangeProtection(IntPtr address, uint size, MemoryProtection protection, out MemoryProtection oldProtect)
+        internal static bool ChangeProtection(IntPtr address, uint size, MemoryProtection protection, out MemoryProtection oldProtect)
         {
             if(!VirtualProtect(address, size, protection, out oldProtect))
             {

--- a/src/CoreHook.Memory/Processes/ProcessCreation.cs
+++ b/src/CoreHook.Memory/Processes/ProcessCreation.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace CoreHook.Memory.Windows
+namespace CoreHook.Memory.Processes
 {
     static class NativeAPI_x86
     {
@@ -140,88 +140,7 @@ namespace CoreHook.Memory.Windows
 
     public static class NativeAPI
     {
-        public const int MAX_HOOK_COUNT = 1024;
-        public const int MAX_ACE_COUNT = 128;
         public readonly static bool Is64Bit = IntPtr.Size == 8;
-
-        [DllImport("kernel32.dll")]
-        public static extern int GetCurrentThreadId();
-
-        [DllImport("kernel32.dll")]
-        public static extern void CloseHandle(IntPtr InHandle);
-
-        [DllImport("kernel32.dll")]
-        public static extern int GetCurrentProcessId();
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Ansi)]
-        public static extern IntPtr GetProcAddress(IntPtr InModule, string InProcName);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        public static extern IntPtr LoadLibrary(string InPath);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        public static extern IntPtr GetModuleHandle(string InPath);
-
-        [DllImport("kernel32.dll")]
-        public static extern short RtlCaptureStackBackTrace(
-            int InFramesToSkip,
-            int InFramesToCapture,
-            IntPtr OutBackTrace,
-            IntPtr OutBackTraceHash);
-
-        public const int STATUS_SUCCESS = unchecked((int)0);
-        public const int STATUS_INVALID_PARAMETER = unchecked((int)0xC000000DL);
-        public const int STATUS_INVALID_PARAMETER_1 = unchecked((int)0xC00000EFL);
-        public const int STATUS_INVALID_PARAMETER_2 = unchecked((int)0xC00000F0L);
-        public const int STATUS_INVALID_PARAMETER_3 = unchecked((int)0xC00000F1L);
-        public const int STATUS_INVALID_PARAMETER_4 = unchecked((int)0xC00000F2L);
-        public const int STATUS_INVALID_PARAMETER_5 = unchecked((int)0xC00000F3L);
-        public const int STATUS_NOT_SUPPORTED = unchecked((int)0xC00000BBL);
-
-        public const int STATUS_INTERNAL_ERROR = unchecked((int)0xC00000E5L);
-        public const int STATUS_INSUFFICIENT_RESOURCES = unchecked((int)0xC000009AL);
-        public const int STATUS_BUFFER_TOO_SMALL = unchecked((int)0xC0000023L);
-        public const int STATUS_NO_MEMORY = unchecked((int)0xC0000017L);
-        public const int STATUS_WOW_ASSERTION = unchecked((int)0xC0009898L);
-        public const int STATUS_ACCESS_DENIED = unchecked((int)0xC0000022L);
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct SECURITY_ATTRIBUTES
-        {
-            public int nLength;
-            public IntPtr lpSecurityDescriptor;
-            public int bInheritHandle;
-        }
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public struct STARTUPINFO
-        {
-            public int cb;
-            public string lpReserved;
-            public string lpDesktop;
-            public string lpTitle;
-            public int dwX;
-            public int dwY;
-            public int dwXSize;
-            public int dwYSize;
-            public int dwXCountChars;
-            public int dwYCountChars;
-            public int dwFillAttribute;
-            public int dwFlags;
-            public short wShowWindow;
-            public short cbReserved2;
-            public IntPtr lpReserved2;
-            public IntPtr hStdInput;
-            public IntPtr hStdOutput;
-            public IntPtr hStdError;
-        }
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct PROCESS_INFORMATION
-        {
-            public IntPtr hProcess;
-            public IntPtr hThread;
-            public int dwProcessId;
-            public int dwThreadId;
-        }
  
         public static bool DetourCreateProcessWithDllExA(
             string lpApplicationName,

--- a/src/CoreHook.Memory/Processes/ProcessManager.Windows.cs
+++ b/src/CoreHook.Memory/Processes/ProcessManager.Windows.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 using System.IO;
 using Microsoft.Win32.SafeHandles;
 
-namespace CoreHook.Memory.Windows
+namespace CoreHook.Memory.Processes
 {
     public sealed partial class ProcessManager : IProcessManager
     {
@@ -62,6 +62,13 @@ namespace CoreHook.Memory.Windows
 
         public void InjectBinary(string modulePath)
         {
+            ExecuteRemoteFunction(Path.Combine(
+                             Environment.ExpandEnvironmentVariables("%Windir%"),
+                             "System32",
+                             "kernel32.dll"
+                             ), "LoadLibraryW",
+            Encoding.Unicode.GetBytes(modulePath + "\0"));
+            /*
             SafeWaitHandle hThread = null;
             using (var hProcess = GetProcessHandle(_processHandle.Id,
                 Interop.Advapi32.ProcessOptions.PROCESS_CREATE_THREAD |
@@ -135,7 +142,7 @@ namespace CoreHook.Memory.Windows
                         new UIntPtr(0),
                         Interop.Kernel32.FreeType.Release);
                 }
-            }
+            }*/
         }
 
         /// <summary>
@@ -224,7 +231,84 @@ namespace CoreHook.Memory.Windows
                 }
             }
         }
+        private IntPtr ExecuteRemoteFunction(string module, string function, byte[] arguments, bool canWait = true)
+        {
+            SafeWaitHandle hThread = null;
+            using (var hProcess = GetProcessHandle(_processHandle.Id,
+                Interop.Advapi32.ProcessOptions.PROCESS_CREATE_THREAD |
+                Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION |
+                Interop.Advapi32.ProcessOptions.PROCESS_VM_OPERATION |
+                Interop.Advapi32.ProcessOptions.PROCESS_VM_READ |
+                Interop.Advapi32.ProcessOptions.PROCESS_VM_WRITE))
+            {
 
+                // Allocate space in the remote process for the DLL path.
+                IntPtr remoteAllocAddr = Interop.Kernel32.VirtualAllocEx(
+                    hProcess,
+                    IntPtr.Zero,
+                    new UIntPtr((uint)arguments.Length),
+                    Interop.Kernel32.AllocationType.Commit | Interop.Kernel32.AllocationType.Reserve,
+                    Interop.Kernel32.MemoryProtection.ReadWrite);
+
+                if (remoteAllocAddr == IntPtr.Zero)
+                {
+                    throw new Win32Exception("Failed to allocate memory in remote process.");
+                }
+
+                try
+                {
+                    // Write the DLL path to the allocated memory.
+                    bool result = Interop.Kernel32.WriteProcessMemory(
+                        hProcess,
+                        remoteAllocAddr,
+                        arguments,
+                        arguments.Length,
+                        out IntPtr bytesWritten);
+
+                    if (!result || bytesWritten.ToInt32() != arguments.Length)
+                    {
+                        throw new Win32Exception("Failed to allocate memory in remote process.");
+                    }
+
+                    // Create a thread in the process at LoadLibraryW and pass it the DLL path.
+                    hThread = Interop.Kernel32.CreateRemoteThread(
+                        hProcess,
+                        IntPtr.Zero,
+                        UIntPtr.Zero,
+                        GetAbsoluteFunctionAddressEx(module, function),
+                        remoteAllocAddr,
+                        0,
+                        IntPtr.Zero);
+
+                    if (hThread.IsInvalid)
+                    {
+                        throw new Win32Exception("Failed to create thread in remote process.");
+                    }
+
+                    if (canWait)
+                    {
+                        const int infiniteWait = -1;
+                        Interop.Kernel32.WaitForSingleObject(
+                            hThread,
+                            infiniteWait);
+                    }
+                    
+                    return remoteAllocAddr;
+                }
+                finally
+                {
+                    hThread?.Dispose();
+                    if (canWait)
+                    {
+                        Interop.Kernel32.VirtualFreeEx(
+                            hProcess,
+                            remoteAllocAddr,
+                            new UIntPtr(0),
+                            Interop.Kernel32.FreeType.Release);
+                    }
+                }
+            }
+        }
         private IntPtr MemAllocate(int size)
         {
             using (var hProcess = GetProcessHandle(_processHandle.Id,

--- a/src/CoreHook.Memory/Processes/ProcessManager.Windows.cs
+++ b/src/CoreHook.Memory/Processes/ProcessManager.Windows.cs
@@ -62,7 +62,7 @@ namespace CoreHook.Memory.Processes
 
         public void InjectBinary(string modulePath)
         {
-            ExecuteRemoteFunction(Path.Combine(
+            ExecuteFuntion(Path.Combine(
                              Environment.ExpandEnvironmentVariables("%Windir%"),
                              "System32",
                              "kernel32.dll"
@@ -80,14 +80,14 @@ namespace CoreHook.Memory.Processes
         /// or we need to cleanup later.</param>
         public IntPtr Execute(string module, string function, byte[] arguments, bool canWait = true)
         {
-            return ExecuteRemoteFunction(
+            return ExecuteFuntion(
                 module,
                 function,
                 arguments,
                 canWait);
         }
 
-        private IntPtr ExecuteRemoteFunction(string module, string function, byte[] arguments, bool canWait = true)
+        private IntPtr ExecuteFuntion(string module, string function, byte[] arguments, bool canWait = true)
         {
             SafeWaitHandle hThread = null;
             using (var hProcess = GetProcessHandle(_processHandle.Id,


### PR DESCRIPTION
Rename **ExecuteRemoteFunction** to **ExecuteFunction** and combine the code to execute a function using the Windows function _CreateRemoteThread_  to reduce code re-use.