### PR TITLE
Test: Add complex parameter plugin test

### DIFF
--- a/CoreHook.sln
+++ b/CoreHook.sln
@@ -59,6 +59,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{6F6AB2
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreHook.Examples.Common", "examples\Common\CoreHook.Examples.Common\CoreHook.Examples.Common.csproj", "{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreHook.Tests.ComplexParameterTest", "tests\hook\CoreHook.Tests.ComplexParameterTest\CoreHook.Tests.ComplexParameterTest.csproj", "{AF446E9D-9530-4DBE-BD44-9BCF7D569AB6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreHook.Tests.Plugins.Shared", "tests\hook\CoreHook.Tests.Plugins.Shared\CoreHook.Tests.Plugins.Shared.csproj", "{5C04FCAA-2E32-44EC-B838-B432CFCBB073}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -137,6 +141,14 @@ Global
 		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF446E9D-9530-4DBE-BD44-9BCF7D569AB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF446E9D-9530-4DBE-BD44-9BCF7D569AB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF446E9D-9530-4DBE-BD44-9BCF7D569AB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF446E9D-9530-4DBE-BD44-9BCF7D569AB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C04FCAA-2E32-44EC-B838-B432CFCBB073}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C04FCAA-2E32-44EC-B838-B432CFCBB073}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C04FCAA-2E32-44EC-B838-B432CFCBB073}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C04FCAA-2E32-44EC-B838-B432CFCBB073}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -165,6 +177,8 @@ Global
 		{A3BAA2B1-64C9-42E1-BD46-F49AC4A4EF12} = {E601DB0A-91DB-45DD-928B-B9CF3BD65026}
 		{6F6AB2BD-CB01-4B87-88B0-BA00D15BD8D5} = {C1E373D4-037B-4479-9AF5-EE4E08642585}
 		{74E65AD3-BCD9-4580-A5ED-8972D5A3AAA0} = {6F6AB2BD-CB01-4B87-88B0-BA00D15BD8D5}
+		{AF446E9D-9530-4DBE-BD44-9BCF7D569AB6} = {BFEBEA69-1024-42F8-A2D5-B1B43E6CE719}
+		{5C04FCAA-2E32-44EC-B838-B432CFCBB073} = {BFEBEA69-1024-42F8-A2D5-B1B43E6CE719}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F1E6A8F-CBCB-4F01-B2C4-446C6F3AD674}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' != ''">
+    <ConfigurationGroup Condition="$(Configuration.EndsWith('Debug'))">Debug</ConfigurationGroup>
+    <ConfigurationGroup Condition="$(Configuration.EndsWith('Release'))">Release</ConfigurationGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <SourceDir>$(ProjectDir)src\</SourceDir>
     <CommonPath>$(SourceDir)Common\src</CommonPath>
+    <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)Build/bin/</BinDir>
+    <OutputDir>$(BinDir)$(Configuration)/netcoreapp2.1/$(Platform)/</OutputDir>    
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ CoreHook supports application function call interception on various architecture
 | Windows Server 2008 | x86, x64              |
 | Windows Server 2012 | x86, x64              |
 | Windows Server 2016 | x86, x64              |
+| Windows Server 2019 | x86, x64              |
 
 ## Dependencies
 
@@ -96,7 +97,7 @@ set CORE_ROOT_64=C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.5
 set CORE_ROOT_32=C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App\2.1.5
 ```
 
-Then open the `CoreHook` solution in `Visual Studio` and you can build the examples, either `CoreHook.FileMonitor` or `CoreHook.UWP.FileMonitor`.
+Then, you can either open the `CoreHook` solution in `Visual Studio` or run `dotnet build` to build the library and the examples.
 
 Finally, build or download the binary releases (in ZIP files) from [CoreHook.Hooking](https://github.com/unknownv2/CoreHook.Hooking) and [CoreHook.Host](https://github.com/unknownv2/CoreHook.Host). Place the `corerundll32.dll (X86, ARM)` and/or `corerundll64.dll (X64, ARM64)` binaries in the output directory of your program. Then, place the `corehook32.dll (X86, ARM)` and/or `corehook64.dll (X64, ARM64)` binaries in the same output directory. These are all of the required files for using the examples above. 
 
@@ -174,7 +175,7 @@ will create a folder called `Publish/win32/win10-arm/` containing the `CoreHook.
 ```ps
 .\publish -example uwp -runtime win10-arm64
 ```
-will create a folder called `Publish/uwp/win10-arm64/` containing the `CoreHook.UWP.FileMonitor` example.
+will create a folder called `Publish/uwp/win10-arm64/` containing the `CoreHook.Uwp.FileMonitor` example.
 
 
 ### Windows Symbol Support

--- a/examples/Common/CoreHook.Examples.Common/CoreHook.Examples.Common.csproj
+++ b/examples/Common/CoreHook.Examples.Common/CoreHook.Examples.Common.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Uwp/CoreHook.Uwp.FileMonitor.Hook/CoreHook.Uwp.FileMonitor.Hook.csproj
+++ b/examples/Uwp/CoreHook.Uwp.FileMonitor.Hook/CoreHook.Uwp.FileMonitor.Hook.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU\Hook</OutputPath>
+    <OutputPath>$(OutputDir)Hook</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\AnyCPU\Hook</OutputPath>
+    <OutputPath>$(OutputDir)Hook</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />    
   </PropertyGroup>

--- a/examples/Uwp/CoreHook.Uwp.FileMonitor.Shared/CoreHook.Uwp.FileMonitor.Shared.csproj
+++ b/examples/Uwp/CoreHook.Uwp.FileMonitor.Shared/CoreHook.Uwp.FileMonitor.Shared.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />    
   </PropertyGroup>

--- a/examples/Uwp/CoreHook.Uwp.FileMonitor/CoreHook.Uwp.FileMonitor.csproj
+++ b/examples/Uwp/CoreHook.Uwp.FileMonitor/CoreHook.Uwp.FileMonitor.csproj
@@ -10,12 +10,12 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
-    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/examples/Win32/CoreHook.FileMonitor.Hook/CoreHook.FileMonitor.Hook.csproj
+++ b/examples/Win32/CoreHook.FileMonitor.Hook/CoreHook.FileMonitor.Hook.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU\Hook</OutputPath>
+    <OutputPath>$(OutputDir)Hook</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\AnyCPU\Hook</OutputPath>
+    <OutputPath>$(OutputDir)Hook</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/examples/Win32/CoreHook.FileMonitor.Service/CoreHook.FileMonitor.Service.csproj
+++ b/examples/Win32/CoreHook.FileMonitor.Service/CoreHook.FileMonitor.Service.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/examples/Win32/CoreHook.FileMonitor.Shared/CoreHook.FileMonitor.Shared.csproj
+++ b/examples/Win32/CoreHook.FileMonitor.Shared/CoreHook.FileMonitor.Shared.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/examples/Win32/CoreHook.FileMonitor/CoreHook.FileMonitor.csproj
+++ b/examples/Win32/CoreHook.FileMonitor/CoreHook.FileMonitor.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />    

--- a/src/CoreHook.BinaryInjection/CoreHook.BinaryInjection.csproj
+++ b/src/CoreHook.BinaryInjection/CoreHook.BinaryInjection.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Platforms>AnyCPU;x86</Platforms>
+    <Platforms>AnyCPU</Platforms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/src/CoreHook.CoreLoad/CoreHook.CoreLoad.csproj
+++ b/src/CoreHook.CoreLoad/CoreHook.CoreLoad.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />   
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />       
   </PropertyGroup>

--- a/src/CoreHook.DependencyModel/CoreHook.DependencyModel.csproj
+++ b/src/CoreHook.DependencyModel/CoreHook.DependencyModel.csproj
@@ -9,11 +9,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <OutputPath>..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/src/CoreHook.IPC/CoreHook.IPC.csproj
+++ b/src/CoreHook.IPC/CoreHook.IPC.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/src/CoreHook.ManagedHook/CoreHook.ManagedHook.csproj
+++ b/src/CoreHook.ManagedHook/CoreHook.ManagedHook.csproj
@@ -9,11 +9,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <OutputPath>..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/src/CoreHook.Memory/CoreHook.Memory.csproj
+++ b/src/CoreHook.Memory/CoreHook.Memory.csproj
@@ -6,13 +6,13 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath> 
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <WarningsAsErrors />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <WarningsAsErrors />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/CoreHook/CoreHook.csproj
+++ b/src/CoreHook/CoreHook.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/tests/CoreHook.Tests/CoreHook.Tests.csproj
+++ b/tests/CoreHook.Tests/CoreHook.Tests.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\..\src\CoreHook.IPC\CoreHook.IPC.csproj" />
     <ProjectReference Include="..\..\src\CoreHook.ManagedHook\CoreHook.ManagedHook.csproj" />
     <ProjectReference Include="..\..\src\CoreHook\CoreHook.csproj" />
+    <ProjectReference Include="..\hook\CoreHook.Tests.Plugins.Shared\CoreHook.Tests.Plugins.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/CoreHook.Tests/CoreHook.Tests.csproj
+++ b/tests/CoreHook.Tests/CoreHook.Tests.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <Platforms>AnyCPU;x86</Platforms>
+    <Platforms>AnyCPU</Platforms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
     <DefineConstants>TRACE;WIN64</DefineConstants>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
@@ -17,7 +17,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;WIN64</DefineConstants>
-    <OutputPath>..\..\Build\bin\Release\netcoreapp2.1\AnyCPU</OutputPath>
+    <OutputPath>$(OutputDir)</OutputPath>
     <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/CoreHook.Tests/RemoteInjectionTest.cs
+++ b/tests/CoreHook.Tests/RemoteInjectionTest.cs
@@ -15,8 +15,8 @@ namespace CoreHook.Tests
                Resources.GetTestDllPath(
                TestHookLibrary
                ),
-               TestMessage,
-                Resources.GetUniquePipeName());
+               Resources.GetUniquePipeName(),
+               TestMessage);
 
             Assert.Equal(TestMessage, Resources.ReadFromProcess(testProcess));
 
@@ -33,8 +33,8 @@ namespace CoreHook.Tests
                Resources.GetTestDllPath(
                TestHookLibrary
                ),
-               TestMessage,
-               Resources.GetUniquePipeName());
+               Resources.GetUniquePipeName(),
+               TestMessage);
 
             Assert.Equal(TestMessage, Resources.ReadFromProcess(Resources.TargetProcess));
 
@@ -55,9 +55,8 @@ namespace CoreHook.Tests
                Resources.GetTestDllPath(
                TestHookLibrary
                ),
-               TestMessage,
-               Resources.GetUniquePipeName()
-                );
+               Resources.GetUniquePipeName(),
+               TestMessage);
 
             Assert.Equal(TestMessage, Resources.ReadFromProcess(testProcess));
 

--- a/tests/CoreHook.Tests/RemotePluginParameterTest.cs
+++ b/tests/CoreHook.Tests/RemotePluginParameterTest.cs
@@ -1,0 +1,36 @@
+﻿using System.Diagnostics;
+using Xunit;
+using CoreHook.Tests.Plugins.Shared;
+
+namespace CoreHook.Tests
+{
+    public class RemotePluginParameterTest
+    {
+        [Fact]
+        private void TestRemotePluginParameter()
+        {
+            const string TestHookLibrary = "CoreHook.Tests.ComplexParameterTest.dll";
+            const string TestMessage = "Berner";
+            
+            var complexParameter = new ComplexParameter
+            {
+                Message = TestMessage,
+                HostProcessId = Process.GetCurrentProcess().Id
+            };
+
+            var testProcess = Resources.TestProcess;
+
+            Resources.InjectDllIntoTarget(testProcess,
+               Resources.GetTestDllPath(
+               TestHookLibrary
+               ),
+               Resources.GetUniquePipeName(),
+               complexParameter);
+
+            Assert.Equal(complexParameter.Message, Resources.ReadFromProcess(testProcess));
+            Assert.Equal(complexParameter.HostProcessId.ToString(), Resources.ReadFromProcess(testProcess));
+
+            Resources.EndTestProcess();
+        }
+    }
+}

--- a/tests/CoreHook.Tests/Resources.cs
+++ b/tests/CoreHook.Tests/Resources.cs
@@ -106,18 +106,12 @@ namespace CoreHook.Tests
 
         internal static void SendToProcess(Process target, string message)
         {
-            using (StreamWriter sw = target.StandardInput)
-            {
-                sw.WriteLine(message);
-            }
+            target.StandardInput.WriteLine(message);
         }
 
         internal static string ReadFromProcess(Process target)
         {
-            using (StreamReader sr = target.StandardOutput)
-            {
-                return sr.ReadLine();
-            }
+            return target.StandardOutput.ReadLine();
         }
  
         internal static string GetTestDllPath(string dllName)
@@ -132,8 +126,9 @@ namespace CoreHook.Tests
         internal static void InjectDllIntoTarget(
             Process target,
             string injectionLibrary,
-            string message,
-            string pipeName)
+            string injectionPipeName,
+            params object[] remoteArguments
+            )
         {
             if (Examples.Common.ModulesPathHelper.GetCoreLoadPaths(target.Is64Bit(),
                 out string coreRunDll, out string coreLibrariesPath,
@@ -151,12 +146,13 @@ namespace CoreHook.Tests
                         PayloadLibrary = injectionLibrary,
                         VerboseLog = false,
                         WaitForDebugger = false,
-                        InjectionPipeName = pipeName
+                        InjectionPipeName = injectionPipeName
                     },
                     new PipePlatformBase(),
-                    message);
+                    remoteArguments);
             }
         }
+
         internal static string GetUniquePipeName()
         {
             return Path.GetRandomFileName();

--- a/tests/CoreHook.Tests/Resources.cs
+++ b/tests/CoreHook.Tests/Resources.cs
@@ -20,17 +20,21 @@ namespace CoreHook.Tests
             {
                 if(_testProcess64 == null)
                 {
-                    _testProcess64 = new Process();
+                    _testProcess64 = new Process
+                    {
+                        StartInfo =
+                        {
+                            FileName = Path.Combine(
+                                Environment.ExpandEnvironmentVariables("%Windir%"),
+                                "System32",
+                                "notepad.exe"
+                            ),
+                            UseShellExecute = false,
+                            RedirectStandardInput = true,
+                            RedirectStandardOutput = true
+                        }
+                    };
 
-                    _testProcess64.StartInfo.FileName = Path.Combine(
-                            Environment.ExpandEnvironmentVariables("%Windir%"),
-                            "System32",
-                            "notepad.exe"
-                            );
-
-                    _testProcess64.StartInfo.UseShellExecute = false;
-                    _testProcess64.StartInfo.RedirectStandardInput = true;
-                    _testProcess64.StartInfo.RedirectStandardOutput = true;
                     _testProcess64.Start();
                 }
                 return _testProcess64;
@@ -42,17 +46,21 @@ namespace CoreHook.Tests
             {
                 if (_testProcess32 == null)
                 {
-                    _testProcess32 = new Process();
+                    _testProcess32 = new Process
+                    {
+                        StartInfo =
+                        {
+                            FileName = Path.Combine(
+                                Environment.ExpandEnvironmentVariables("%Windir%"),
+                                "SysWOW64",
+                                "notepad.exe"
+                            ),
+                            UseShellExecute = false,
+                            RedirectStandardInput = true,
+                            RedirectStandardOutput = true
+                        }
+                    };
 
-                    _testProcess32.StartInfo.FileName = Path.Combine(
-                            Environment.ExpandEnvironmentVariables("%Windir%"),
-                            "SysWOW64",
-                            "notepad.exe"
-                            );
-
-                    _testProcess32.StartInfo.UseShellExecute = false;
-                    _testProcess32.StartInfo.RedirectStandardInput = true;
-                    _testProcess32.StartInfo.RedirectStandardOutput = true;
                     _testProcess32.Start();
                 }
                 return _testProcess32;
@@ -75,22 +83,25 @@ namespace CoreHook.Tests
         internal static Process TargetProcess
         {
             get
-            {                
+            {
                 if (_targetApp == null)
                 {
-                    _targetApp = new Process();
+                    _targetApp = new Process
+                    {
+                        StartInfo =
+                        {
+                            FileName = "dotnet",
+                            Arguments = Path.Combine(
+                                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                                TestModuleDir,
+                                TargetAppName
+                            ),
+                            UseShellExecute = false,
+                            RedirectStandardInput = true,
+                            RedirectStandardOutput = true
+                        }
+                    };
 
-                    _targetApp.StartInfo.FileName = "dotnet";
-                    _targetApp.StartInfo.Arguments =
-                        Path.Combine(
-                            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), 
-                            TestModuleDir, 
-                            TargetAppName
-                        );
-
-                    _targetApp.StartInfo.UseShellExecute = false;
-                    _targetApp.StartInfo.RedirectStandardInput = true;
-                    _targetApp.StartInfo.RedirectStandardOutput = true;
                     _targetApp.Start();
                 }
 

--- a/tests/hook/CoreHook.Tests.ComplexParameterTest/CoreHook.Tests.ComplexParameterTest.csproj
+++ b/tests/hook/CoreHook.Tests.ComplexParameterTest/CoreHook.Tests.ComplexParameterTest.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>        
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>$(OutputDir)Test</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>$(OutputDir)Test</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\CoreHook\CoreHook.csproj" />
+    <ProjectReference Include="..\CoreHook.Tests.Plugins.Shared\CoreHook.Tests.Plugins.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/hook/CoreHook.Tests.ComplexParameterTest/EntryPoint.cs
+++ b/tests/hook/CoreHook.Tests.ComplexParameterTest/EntryPoint.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using CoreHook.Tests.Plugins.Shared;
+
+namespace CoreHook.Tests.ComplexParameterTest
+{
+    public class EntryPoint : IEntryPoint
+    {
+        public EntryPoint(IContext context, ComplexParameter arg1) { }
+
+        public void Run(IContext context, ComplexParameter complexParameter)
+        {
+            Console.WriteLine(complexParameter.Message);
+            Console.WriteLine(complexParameter.HostProcessId);
+        }
+    }
+}

--- a/tests/hook/CoreHook.Tests.Plugins.Shared/ComplexParameter.cs
+++ b/tests/hook/CoreHook.Tests.Plugins.Shared/ComplexParameter.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace CoreHook.Tests.Plugins.Shared
+{
+    [Serializable]
+    public class ComplexParameter
+    {
+        public string Message;
+        public int HostProcessId;
+    }
+}

--- a/tests/hook/CoreHook.Tests.Plugins.Shared/CoreHook.Tests.Plugins.Shared.csproj
+++ b/tests/hook/CoreHook.Tests.Plugins.Shared/CoreHook.Tests.Plugins.Shared.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>        
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>$(OutputDir)Test</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>$(OutputDir)Test</OutputPath>
+  </PropertyGroup>
+
+</Project>

--- a/tests/hook/CoreHook.Tests.SimpleHook1/CoreHook.Tests.SimpleHook1.csproj
+++ b/tests/hook/CoreHook.Tests.SimpleHook1/CoreHook.Tests.SimpleHook1.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU\Test</OutputPath>
+    <OutputPath>$(OutputDir)Test</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\AnyCPU\Test</OutputPath>
+    <OutputPath>$(OutputDir)Test</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/hook/CoreHook.Tests.SimpleHook1/EntryPoint.cs
+++ b/tests/hook/CoreHook.Tests.SimpleHook1/EntryPoint.cs
@@ -2,9 +2,9 @@
 
 namespace CoreHook.Tests.SimpleHook1
 {
-    public class Library : IEntryPoint
+    public class EntryPoint : IEntryPoint
     {
-        public Library(IContext context, string arg1) { }
+        public EntryPoint(IContext context, string arg1) { }
 
         public void Run(IContext context, string message) => Console.WriteLine(message);
     }

--- a/tests/target/CoreHook.Tests.TargetApp/CoreHook.Tests.TargetApp.csproj
+++ b/tests/target/CoreHook.Tests.TargetApp/CoreHook.Tests.TargetApp.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Debug\netcoreapp2.1\AnyCPU\Test</OutputPath>
+    <OutputPath>$(OutputDir)Test</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\Build\bin\Release\netcoreapp2.1\AnyCPU\Test</OutputPath>
+    <OutputPath>$(OutputDir)Test</OutputPath>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Test loading a CoreHook plugin with a class as an argument to make sure we can pass classes remotely instead of just types like strings as in the test plugin SimpleHook1.