### PR TITLE
Grant all app permissions on the pdb files for the UWP CoreHook modules 

### DIFF
--- a/examples/Uwp/CoreHook.Uwp.FileMonitor/Program.cs
+++ b/examples/Uwp/CoreHook.Uwp.FileMonitor/Program.cs
@@ -196,7 +196,7 @@ namespace CoreHook.Uwp.FileMonitor
 
             GrantAllAppPkgsAccessToFolder(directoryPath);
             foreach (var filePath in Directory.GetFiles(directoryPath, "*.*", SearchOption.AllDirectories)
-                    .Where(name => name.EndsWith(".json") || name.EndsWith(".dll")))
+                    .Where(name => name.EndsWith(".json") || name.EndsWith(".dll") || name.EndsWith(".pdb")))
             {
                 GrantFolderRecursive(filePath, directoryPath);
                 GrantAllAppPkgsAccessToFile(filePath);

--- a/src/CoreHook.Memory/ProcessExtensions.cs
+++ b/src/CoreHook.Memory/ProcessExtensions.cs
@@ -28,7 +28,7 @@ namespace CoreHook.Memory
 
                 if (processHandle.IsInvalid)
                 {
-                    throw new Win32Exception("Failed to open process handle");
+                    throw new Win32Exception("Failed to open process query handle.");
                 }
 
                 using (processHandle)
@@ -36,7 +36,7 @@ namespace CoreHook.Memory
                     bool processIsWow64 = false;
                     if (!Interop.Kernel32.IsWow64Process(processHandle, ref processIsWow64))
                     {
-                        throw new Win32Exception("Cannot determine process architecture");
+                        throw new Win32Exception("Determining process architecture with IsWow64Process failed.");
                     }
 
                     return !processIsWow64;
@@ -44,7 +44,7 @@ namespace CoreHook.Memory
             }
             else
             {
-                throw new PlatformNotSupportedException("Cannot determine process architecture");
+                throw new PlatformNotSupportedException("Plaform not supported for detecting process architecture.");
             }
         }
     }


### PR DESCRIPTION
Include pdb (symbol files) in the list of file types to gran ALL APPLICATION PACKAGES to for the UWP FileMonitor example.