### PR TITLE
Update check for the CoreLoad.Load remote parameter from the corerundll

### DIFF
--- a/src/CoreHook.CoreLoad/Loader.cs
+++ b/src/CoreHook.CoreLoad/Loader.cs
@@ -24,7 +24,7 @@ namespace CoreHook.CoreLoad
         {
             try
             {
-                if (remoteParameters == null || remoteParameters == IntPtr.Zero)
+                if (remoteParameters == IntPtr.Zero)
                 {
                     throw new ArgumentOutOfRangeException(nameof(remoteParameters), 
                         "Remote arguments address was zero");


### PR DESCRIPTION
We only need to check for IntPtr.Zero and not ( == null) as well.