### PR TITLE
Refactor BinaryLoaderArguments class

### DIFF
--- a/src/CoreHook.BinaryInjection/BinaryLoader/BinaryLoader.Windows.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/BinaryLoader.Windows.cs
@@ -31,7 +31,7 @@ namespace CoreHook.BinaryInjection.BinaryLoader
             _processManager.Execute(
                 functionName.Module,
                 functionName.Function,
-                Binary.StructToByteArray(arguments),
+                MarshallingHelper.StructToByteArray(arguments),
                 false);
         }
 

--- a/src/CoreHook.BinaryInjection/BinaryLoader/BinaryLoaderArguments.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/BinaryLoaderArguments.cs
@@ -1,22 +1,16 @@
-﻿using System.Text;
-
-namespace CoreHook.BinaryInjection
+﻿
+namespace CoreHook.BinaryInjection.BinaryLoader
 {
-    public class BinaryLoaderArguments
+    public class BinaryLoaderArguments : IBinaryLoaderArguments
     {
-        public bool Verbose;
+        public bool Verbose { get; set; }
 
-        public bool WaitForDebugger;
+        public bool WaitForDebugger { get; set; }
 
-        public string PayloadFileName;
+        public string PayloadFileName { get; set; }
 
-        public string CoreRootPath;
+        public string CoreRootPath { get; set; }
 
-        public string CoreLibrariesPath;
-
-        public static byte[] GetPathArray(string path, int pathLength, Encoding encoding)
-        {
-            return encoding.GetBytes(path.PadRight(pathLength, '\0'));
-        }
+        public string CoreLibrariesPath { get; set; }
     }
 }

--- a/src/CoreHook.BinaryInjection/BinaryLoader/BinaryLoaderArgumentsHelper.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/BinaryLoaderArgumentsHelper.cs
@@ -1,0 +1,12 @@
+﻿using System.Text;
+
+namespace CoreHook.BinaryInjection.BinaryLoader
+{
+    internal static class BinaryLoaderArgumentsHelper
+    {
+        public static byte[] GetPathArray(string path, int pathLength, Encoding encoding)
+        {
+            return encoding.GetBytes(path.PadRight(pathLength, paddingChar: '\0'));
+        }
+    }
+}

--- a/src/CoreHook.BinaryInjection/BinaryLoader/IBinaryLoaderArguments.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/IBinaryLoaderArguments.cs
@@ -1,0 +1,16 @@
+﻿
+namespace CoreHook.BinaryInjection.BinaryLoader
+{
+    public interface IBinaryLoaderArguments
+    {
+        bool Verbose { get; }
+
+        bool WaitForDebugger { get; }
+
+        string PayloadFileName { get; }
+
+        string CoreRootPath { get; }
+
+        string CoreLibrariesPath { get; }
+    }
+}

--- a/src/CoreHook.BinaryInjection/BinaryLoader/Serializer/BinaryLoaderSerializer.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/Serializer/BinaryLoaderSerializer.cs
@@ -4,7 +4,7 @@ namespace CoreHook.BinaryInjection.BinaryLoader.Serializer
 {
     public class BinaryLoaderSerializer : IBinarySerializer
     {
-        public BinaryLoaderArguments Arguments { get; set; }
+        public IBinaryLoaderArguments Arguments { get; set; }
         public IBinaryLoaderConfig Config { get; }
 
         public BinaryLoaderSerializer(IBinaryLoaderConfig config)
@@ -24,9 +24,9 @@ namespace CoreHook.BinaryInjection.BinaryLoader.Serializer
                     writer.Write(Arguments.WaitForDebugger);
                     // Padding for reserved data to align structure to 8 bytes
                     writer.Write(new byte[6]);
-                    writer.Write(BinaryLoaderArguments.GetPathArray(Arguments.PayloadFileName, Config.MaxPathLength, Config.PathEncoding));
-                    writer.Write(BinaryLoaderArguments.GetPathArray(Arguments.CoreRootPath, Config.MaxPathLength, Config.PathEncoding));
-                    writer.Write(BinaryLoaderArguments.GetPathArray(Arguments.CoreLibrariesPath ?? string.Empty, Config.MaxPathLength, Config.PathEncoding));
+                    writer.Write(BinaryLoaderArgumentsHelper.GetPathArray(Arguments.PayloadFileName, Config.MaxPathLength, Config.PathEncoding));
+                    writer.Write(BinaryLoaderArgumentsHelper.GetPathArray(Arguments.CoreRootPath, Config.MaxPathLength, Config.PathEncoding));
+                    writer.Write(BinaryLoaderArgumentsHelper.GetPathArray(Arguments.CoreLibrariesPath ?? string.Empty, Config.MaxPathLength, Config.PathEncoding));
                 }
                 return ms.ToArray();
             }

--- a/src/CoreHook.BinaryInjection/BinaryLoader/Serializer/IBinarySerializer.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/Serializer/IBinarySerializer.cs
@@ -1,13 +1,8 @@
-﻿using System.IO;
-
+﻿
 namespace CoreHook.BinaryInjection.BinaryLoader.Serializer
 {
     public interface IBinarySerializer
     {
         byte[] Serialize();
-    }
-    public interface IBinaryStreamSerializer
-    {
-        void Serialize(MemoryStream stream);
     }
 }

--- a/src/CoreHook.Memory/IMemoryAllocation.cs
+++ b/src/CoreHook.Memory/IMemoryAllocation.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
+﻿
 namespace CoreHook.Memory
 {
     public interface IMemoryAllocation : IPointer, IDisposableState

--- a/src/CoreHook.Memory/MarshallingHelper.cs
+++ b/src/CoreHook.Memory/MarshallingHelper.cs
@@ -2,12 +2,12 @@
 
 namespace CoreHook.Memory
 {
-    public class Binary
+    public static class MarshallingHelper
     {
         public static byte[] StructToByteArray(object obj, int? length = null)
         {
-            var objectLength = Marshal.SizeOf(obj);
-            var arr = new byte[length ?? objectLength];
+            var objectLength = length ?? Marshal.SizeOf(obj);
+            var arr = new byte[objectLength];
 
             var ptr = Marshal.AllocHGlobal(objectLength);
 

--- a/src/CoreHook.Memory/MemoryRegion.cs
+++ b/src/CoreHook.Memory/MemoryRegion.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace CoreHook.Memory
 {

--- a/src/CoreHook/IHookAccessControl.cs
+++ b/src/CoreHook/IHookAccessControl.cs
@@ -6,7 +6,15 @@ namespace CoreHook
     /// </summary>
     public interface IHookAccessControl
     {
+        /// <summary>
+        /// True if the current thread ACL is exclusive, as described in
+        /// <see cref="SetExclusiveACL"/>.
+        /// </summary>
         bool IsExclusive { get; }
+        /// <summary>
+        /// True if the current thread ACL is inclusive, as described in 
+        /// <see cref="SetInclusiveACL"/>.
+        /// </summary>
         bool IsInclusive { get; }
         /// <summary>
         /// Overwrite the current ACL and set an inclusive list of threads.

--- a/src/CoreHook/NativeImport.cs
+++ b/src/CoreHook/NativeImport.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace CoreHook
 {
-    static class NativeAPI_x86
+    internal static class NativeAPI32
     {
         private const string DllName = "corehook32";
 
@@ -166,7 +166,7 @@ namespace CoreHook
             string lpFunction);
     }
 
-    static class NativeAPI_x64
+    internal static class NativeAPI64
     {
         private const string DllName = "corehook64";
 
@@ -392,11 +392,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                return NativeAPI_x64.RtlGetLastError();
+                return NativeAPI64.RtlGetLastError();
             }
             else
             {
-                return NativeAPI_x86.RtlGetLastError();
+                return NativeAPI32.RtlGetLastError();
             }
         }
 
@@ -404,11 +404,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                NativeAPI_x64.DetourUninstallAllHooks();
+                NativeAPI64.DetourUninstallAllHooks();
             }
             else
             {
-                NativeAPI_x86.DetourUninstallAllHooks();
+                NativeAPI32.DetourUninstallAllHooks();
             }
         }
 
@@ -420,12 +420,12 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourInstallHook(entryPoint, hookProcedure, callback, handle));
+                Force(NativeAPI64.DetourInstallHook(entryPoint, hookProcedure, callback, handle));
             }
             else
             {
 
-                Force(NativeAPI_x86.DetourInstallHook(entryPoint, hookProcedure, callback, handle));
+                Force(NativeAPI32.DetourInstallHook(entryPoint, hookProcedure, callback, handle));
             }          
         }
 
@@ -433,11 +433,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourUninstallHook(refHandle));
+                Force(NativeAPI64.DetourUninstallHook(refHandle));
             }
             else
             {
-                Force(NativeAPI_x86.DetourUninstallHook(refHandle));
+                Force(NativeAPI32.DetourUninstallHook(refHandle));
             }
         }
 
@@ -446,11 +446,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourWaitForPendingRemovals());
+                Force(NativeAPI64.DetourWaitForPendingRemovals());
             }
             else
             {
-                Force(NativeAPI_x86.DetourWaitForPendingRemovals());
+                Force(NativeAPI32.DetourWaitForPendingRemovals());
             }
         }
 
@@ -461,11 +461,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourIsThreadIntercepted(handle, threadId, out result));
+                Force(NativeAPI64.DetourIsThreadIntercepted(handle, threadId, out result));
             }
             else
             {
-                Force(NativeAPI_x86.DetourIsThreadIntercepted(handle, threadId, out result));
+                Force(NativeAPI32.DetourIsThreadIntercepted(handle, threadId, out result));
             }
         }
 
@@ -476,11 +476,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourSetInclusiveACL(threadIdList, threadCount, handle));
+                Force(NativeAPI64.DetourSetInclusiveACL(threadIdList, threadCount, handle));
             }
             else
             {
-                Force(NativeAPI_x86.DetourSetInclusiveACL(threadIdList, threadCount, handle));
+                Force(NativeAPI32.DetourSetInclusiveACL(threadIdList, threadCount, handle));
             }
         }
 
@@ -491,11 +491,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourSetExclusiveACL(threadIdList, threadCount, handle));
+                Force(NativeAPI64.DetourSetExclusiveACL(threadIdList, threadCount, handle));
             }
             else
             {
-                Force(NativeAPI_x86.DetourSetExclusiveACL(threadIdList, threadCount, handle));
+                Force(NativeAPI32.DetourSetExclusiveACL(threadIdList, threadCount, handle));
             }
         }
 
@@ -505,11 +505,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourSetGlobalInclusiveACL(threadIdList, threadCount));
+                Force(NativeAPI64.DetourSetGlobalInclusiveACL(threadIdList, threadCount));
             }
             else
             {
-                Force(NativeAPI_x86.DetourSetGlobalInclusiveACL(threadIdList, threadCount));
+                Force(NativeAPI32.DetourSetGlobalInclusiveACL(threadIdList, threadCount));
             }
         }
 
@@ -519,11 +519,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourSetGlobalExclusiveACL(threadIdList, threadCount));
+                Force(NativeAPI64.DetourSetGlobalExclusiveACL(threadIdList, threadCount));
             }
             else
             {
-                Force(NativeAPI_x86.DetourSetGlobalExclusiveACL(threadIdList, threadCount));
+                Force(NativeAPI32.DetourSetGlobalExclusiveACL(threadIdList, threadCount));
             }
         }
 
@@ -532,11 +532,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourBarrierGetCallingModule(out returnValue));
+                Force(NativeAPI64.DetourBarrierGetCallingModule(out returnValue));
             }
             else
             {
-                Force(NativeAPI_x86.DetourBarrierGetCallingModule(out returnValue));
+                Force(NativeAPI32.DetourBarrierGetCallingModule(out returnValue));
             }
         }
 
@@ -544,11 +544,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                return NativeAPI_x64.DetourBarrierGetCallback(out returnValue);
+                return NativeAPI64.DetourBarrierGetCallback(out returnValue);
             }
             else
             {
-                return NativeAPI_x86.DetourBarrierGetCallback(out returnValue);
+                return NativeAPI32.DetourBarrierGetCallback(out returnValue);
             }
         }
 
@@ -556,11 +556,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourBarrierGetReturnAddress(out returnValue));
+                Force(NativeAPI64.DetourBarrierGetReturnAddress(out returnValue));
             }
             else
             {
-                Force(NativeAPI_x86.DetourBarrierGetReturnAddress(out returnValue));
+                Force(NativeAPI32.DetourBarrierGetReturnAddress(out returnValue));
             }
         }
 
@@ -568,11 +568,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourBarrierGetAddressOfReturnAddress(out returnValue));
+                Force(NativeAPI64.DetourBarrierGetAddressOfReturnAddress(out returnValue));
             }
             else
             {
-                Force(NativeAPI_x86.DetourBarrierGetAddressOfReturnAddress(out returnValue));
+                Force(NativeAPI32.DetourBarrierGetAddressOfReturnAddress(out returnValue));
             }
         }
 
@@ -580,11 +580,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourBarrierBeginStackTrace(out backup));
+                Force(NativeAPI64.DetourBarrierBeginStackTrace(out backup));
             }
             else
             {
-                Force(NativeAPI_x86.DetourBarrierBeginStackTrace(out backup));
+                Force(NativeAPI32.DetourBarrierBeginStackTrace(out backup));
             }
         }
 
@@ -592,11 +592,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourBarrierCallStackTrace(backup, maxCount, out outMaxCount));
+                Force(NativeAPI64.DetourBarrierCallStackTrace(backup, maxCount, out outMaxCount));
             }
             else
             {
-                Force(NativeAPI_x86.DetourBarrierCallStackTrace(backup, maxCount, out outMaxCount));
+                Force(NativeAPI32.DetourBarrierCallStackTrace(backup, maxCount, out outMaxCount));
             }
 
         }
@@ -604,11 +604,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourBarrierEndStackTrace(backup));
+                Force(NativeAPI64.DetourBarrierEndStackTrace(backup));
             }
             else
             {
-                Force(NativeAPI_x86.DetourBarrierEndStackTrace(backup));
+                Force(NativeAPI32.DetourBarrierEndStackTrace(backup));
             }
         }
 
@@ -616,11 +616,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeAPI_x64.DetourGetHookBypassAddress(handle, out address));
+                Force(NativeAPI64.DetourGetHookBypassAddress(handle, out address));
             }
             else
             {
-                Force(NativeAPI_x86.DetourGetHookBypassAddress(handle, out address));
+                Force(NativeAPI32.DetourGetHookBypassAddress(handle, out address));
             }
 
         }
@@ -641,7 +641,7 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                return (NativeAPI_x64.DetourCreateProcessWithDllExA(
+                return (NativeAPI64.DetourCreateProcessWithDllExA(
                         lpApplicationName,
                         lpCommandLine,
                         lpProcessAttributes,
@@ -657,7 +657,7 @@ namespace CoreHook
             }
             else
             {
-                return (NativeAPI_x86.DetourCreateProcessWithDllExA(
+                return (NativeAPI32.DetourCreateProcessWithDllExA(
                         lpApplicationName,
                         lpCommandLine,
                         lpProcessAttributes,
@@ -688,7 +688,7 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                return (NativeAPI_x64.DetourCreateProcessWithDllExW(
+                return (NativeAPI64.DetourCreateProcessWithDllExW(
                         lpApplicationName,
                         lpCommandLine,
                         lpProcessAttributes,
@@ -704,7 +704,7 @@ namespace CoreHook
             }
             else
             {
-                return (NativeAPI_x86.DetourCreateProcessWithDllExW(
+                return (NativeAPI32.DetourCreateProcessWithDllExW(
                         lpApplicationName,
                         lpCommandLine,
                         lpProcessAttributes,
@@ -736,7 +736,7 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                return (NativeAPI_x64.DetourCreateProcessWithDllsExA(
+                return (NativeAPI64.DetourCreateProcessWithDllsExA(
                         lpApplicationName,
                         lpCommandLine,
                         lpProcessAttributes,
@@ -753,7 +753,7 @@ namespace CoreHook
             }
             else
             {
-                return (NativeAPI_x86.DetourCreateProcessWithDllsExA(
+                return (NativeAPI32.DetourCreateProcessWithDllsExA(
                         lpApplicationName,
                         lpCommandLine,
                         lpProcessAttributes,
@@ -786,7 +786,7 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                return (NativeAPI_x64.DetourCreateProcessWithDllsExW(
+                return (NativeAPI64.DetourCreateProcessWithDllsExW(
                         lpApplicationName,
                         lpCommandLine,
                         lpProcessAttributes,
@@ -803,7 +803,7 @@ namespace CoreHook
             }
             else
             {
-                return (NativeAPI_x86.DetourCreateProcessWithDllsExW(
+                return (NativeAPI32.DetourCreateProcessWithDllsExW(
                         lpApplicationName,
                         lpCommandLine,
                         lpProcessAttributes,
@@ -825,12 +825,12 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                return (NativeAPI_x64.DetourFindFunction(lpModule,
+                return (NativeAPI64.DetourFindFunction(lpModule,
                     lpFunction));
             }
             else
             {
-                return (NativeAPI_x86.DetourFindFunction(lpModule,
+                return (NativeAPI32.DetourFindFunction(lpModule,
                     lpFunction));
             }
         }


### PR DESCRIPTION
* Use IBinaryLoaderArguments instead of the concrete BinaryLoaderArguments class

* Rename the "Binary" class to "MarshallingHelper" to better describe it

* Rename NativeAPI{x86,x64} to NativeAPI{32,64} since we are using CoreHook for other architectures such as ARM32 and ARM64