### PR TITLE
refactor: Remove WaitForDebugger option for initializing CoreCLR

### DIFF
--- a/examples/Uwp/CoreHook.Uwp.FileMonitor/Program.cs
+++ b/examples/Uwp/CoreHook.Uwp.FileMonitor/Program.cs
@@ -39,10 +39,6 @@ namespace CoreHook.Uwp.FileMonitor
         /// </summary>
         private const bool HostVerboseLog = false;
         /// <summary>
-        /// Wait for a debugger to attach to the target process before running any .NET assemblies.
-        /// </summary>
-        private const bool HostWaitForDebugger = false;
-        /// <summary>
         /// Class that handles creating a named pipe server for communicating with the target process.
         /// </summary>
         private static readonly IPipePlatform PipePlatform = new Pipe.PipePlatform();
@@ -148,8 +144,7 @@ namespace CoreHook.Uwp.FileMonitor
                         HostLibrary = coreRunDll,
                         InjectionPipeName = injectionPipeName,
                         PayloadLibrary = injectionLibrary,
-                        VerboseLog = HostVerboseLog,
-                        WaitForDebugger = HostWaitForDebugger
+                        VerboseLog = HostVerboseLog
                     },
                     PipePlatform,
                     CoreHookPipeName);

--- a/examples/Win32/CoreHook.FileMonitor/Program.cs
+++ b/examples/Win32/CoreHook.FileMonitor/Program.cs
@@ -35,10 +35,6 @@ namespace CoreHook.FileMonitor
         /// </summary>
         private const bool HostVerboseLog = false;
         /// <summary>
-        /// Wait for a debugger to attach to the target process before running any .NET assemblies.
-        /// </summary>
-        private const bool HostWaitForDebugger = false;
-        /// <summary>
         /// Class that handles creating a named pipe server for communicating with the target process.
         /// </summary>
         private static readonly IPipePlatform PipePlatform = new PipePlatform();
@@ -152,8 +148,7 @@ namespace CoreHook.FileMonitor
                          CLRBootstrapLibrary = coreLoadLibrary,
                          InjectionPipeName = injectionPipeName,
                          PayloadLibrary = injectionLibrary,
-                         VerboseLog = HostVerboseLog,
-                         WaitForDebugger = HostWaitForDebugger
+                         VerboseLog = HostVerboseLog
                      },
                      PipePlatform,
                      out _,
@@ -192,8 +187,7 @@ namespace CoreHook.FileMonitor
                         HostLibrary = coreRunDll,
                         InjectionPipeName = injectionPipeName,
                         PayloadLibrary = injectionLibrary,
-                        VerboseLog = HostVerboseLog,
-                        WaitForDebugger = HostWaitForDebugger,
+                        VerboseLog = HostVerboseLog
                     },
                     PipePlatform,
                     CoreHookPipeName);

--- a/src/CoreHook.BinaryInjection/BinaryLoader/BinaryLoaderArguments.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/BinaryLoaderArguments.cs
@@ -4,13 +4,8 @@ namespace CoreHook.BinaryInjection.BinaryLoader
     public class BinaryLoaderArguments : IBinaryLoaderArguments
     {
         public bool Verbose { get; set; }
-
-        public bool WaitForDebugger { get; set; }
-
         public string PayloadFileName { get; set; }
-
         public string CoreRootPath { get; set; }
-
         public string CoreLibrariesPath { get; set; }
     }
 }

--- a/src/CoreHook.BinaryInjection/BinaryLoader/IBinaryLoaderArguments.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/IBinaryLoaderArguments.cs
@@ -4,13 +4,8 @@ namespace CoreHook.BinaryInjection.BinaryLoader
     public interface IBinaryLoaderArguments
     {
         bool Verbose { get; }
-
-        bool WaitForDebugger { get; }
-
         string PayloadFileName { get; }
-
         string CoreRootPath { get; }
-
         string CoreLibrariesPath { get; }
     }
 }

--- a/src/CoreHook.BinaryInjection/BinaryLoader/Serializer/BinaryLoaderSerializer.cs
+++ b/src/CoreHook.BinaryInjection/BinaryLoader/Serializer/BinaryLoaderSerializer.cs
@@ -21,9 +21,8 @@ namespace CoreHook.BinaryInjection.BinaryLoader.Serializer
                     // Serialize information about the serialized class 
                     // Data that is passed to the remote function
                     writer.Write(Arguments.Verbose);
-                    writer.Write(Arguments.WaitForDebugger);
                     // Padding for reserved data to align structure to 8 bytes
-                    writer.Write(new byte[6]);
+                    writer.Write(new byte[7]);
                     writer.Write(BinaryLoaderArgumentsHelper.GetPathArray(Arguments.PayloadFileName, Config.MaxPathLength, Config.PathEncoding));
                     writer.Write(BinaryLoaderArgumentsHelper.GetPathArray(Arguments.CoreRootPath, Config.MaxPathLength, Config.PathEncoding));
                     writer.Write(BinaryLoaderArgumentsHelper.GetPathArray(Arguments.CoreLibrariesPath ?? string.Empty, Config.MaxPathLength, Config.PathEncoding));

--- a/src/CoreHook.ManagedHook/Remote/RemoteHooking.cs
+++ b/src/CoreHook.ManagedHook/Remote/RemoteHooking.cs
@@ -239,7 +239,6 @@ namespace CoreHook.ManagedHook.Remote
                                             Arguments = new BinaryLoaderArguments
                                             {
                                                 Verbose = remoteHookConfig.VerboseLog,
-                                                WaitForDebugger = remoteHookConfig.WaitForDebugger,
                                                 PayloadFileName = remoteHookConfig.CLRBootstrapLibrary,
                                                 CoreRootPath = remoteHookConfig.CoreCLRPath,
                                                 CoreLibrariesPath = remoteHookConfig.CoreCLRLibrariesPath

--- a/src/CoreHook.ManagedHook/Remote/RemoteHookingConfig.cs
+++ b/src/CoreHook.ManagedHook/Remote/RemoteHookingConfig.cs
@@ -38,11 +38,6 @@ namespace CoreHook.ManagedHook.Remote
         /// </summary>
         public bool VerboseLog { get; set; }
         /// <summary>
-        /// Option to enable waiting for a debugger to attach before any 
-        /// .NET Assemblies are loaded by the HostLibrary.
-        /// </summary>
-        public bool WaitForDebugger { get; set; }
-        /// <summary>
         /// Library that resolves dependencies and passes arguments to
         /// the .NET payload Assembly.
         /// </summary>
@@ -136,10 +131,5 @@ namespace CoreHook.ManagedHook.Remote
         /// Option to enable the logging module inside the HostLibrary.
         /// </summary>
         bool VerboseLog { get; set; }
-        /// <summary>
-        /// Option to enable waiting for a debugger to attach before any 
-        /// .NET Assemblies are loaded by the HostLibrary.
-        /// </summary>
-        bool WaitForDebugger { get; set; }
     }
 }

--- a/src/CoreHook.Memory/IMemoryWriter.cs
+++ b/src/CoreHook.Memory/IMemoryWriter.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
+﻿
 namespace CoreHook.Memory
 {
     public interface IMemoryWriter

--- a/tests/CoreHook.Tests/Resources.cs
+++ b/tests/CoreHook.Tests/Resources.cs
@@ -178,7 +178,6 @@ namespace CoreHook.Tests
                         DetourLibrary = coreHookDll,
                         PayloadLibrary = injectionLibrary,
                         VerboseLog = false,
-                        WaitForDebugger = false,
                         InjectionPipeName = injectionPipeName
                     },
                     new PipePlatformBase(),


### PR DESCRIPTION
Remove the WaitForDebugger option since we are removing it from the CoreHook.Host corerundll project to simplify/reduce the code.