### PR TITLE
Refactor config classes and remove interfaces

### DIFF
--- a/src/CoreHook.BinaryInjection/ProcessUtils/ProcessCreationConfig.cs
+++ b/src/CoreHook.BinaryInjection/ProcessUtils/ProcessCreationConfig.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CoreHook.BinaryInjection.ProcessUtils
+{
+    public class ProcessCreationConfig
+    {
+        /// <summary>
+        /// Filepath to an executable program on the system that is to be launched.
+        /// </summary>
+        public string ExecutablePath { get; set; }
+        /// <summary>
+        /// Arguments to be passed to the executable program when it is started
+        /// </summary>
+        public string CommandLine { get; set; }
+        /// <summary>
+        /// Attributes and options passed to the process creation function call.
+        /// </summary>
+        public uint ProcessCreationFlags { get; set; }
+    }
+}

--- a/src/CoreHook.BinaryInjection/RemoteInjection/CoreHookNativeConfig.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/CoreHookNativeConfig.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CoreHook.BinaryInjection.RemoteInjection
+{
+    public class CoreHookNativeConfig
+    {
+        /// <summary>
+        /// Library that initializes the .NET Core runtime (CoreCLR) and allows
+        /// loading and executing .NET Assemblies.
+        /// </summary>
+        public string HostLibrary { get; set; }
+        /// <summary>
+        /// Library that implements function intercept exports for the LocalHook class
+        /// such as DetourInstallHook.
+        /// </summary>
+        public string DetourLibrary { get; set; }
+        /// <summary>
+        /// Directory path which contains the main CoreCLR modules for hosting the runtime
+        /// such as CoreCLR and clrjit libraries.
+        /// </summary>
+        public string CoreCLRPath { get; set; }
+        /// <summary>
+        /// Directory path which contains the CoreCLR Assembly reference
+        /// runtime libraries such as System.Private.CoreLib.dll.
+        /// </summary>
+        public string CoreCLRLibrariesPath { get; set; }
+    }
+}

--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
@@ -12,6 +12,7 @@ using CoreHook.CoreLoad.Data;
 using CoreHook.IPC.Platform;
 using CoreHook.Memory;
 using CoreHook.Memory.Processes;
+using CoreHook.BinaryInjection.ProcessUtils;
 using static CoreHook.BinaryInjection.ProcessUtils.ProcessHelper;
 
 namespace CoreHook.BinaryInjection.RemoteInjection

--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjectorConfig.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjectorConfig.cs
@@ -1,44 +1,6 @@
 ﻿
 namespace CoreHook.BinaryInjection.RemoteInjection
 {
-    public class ProcessCreationConfig
-    {
-        /// <summary>
-        /// Filepath to an executable program on the system that is to be launched.
-        /// </summary>
-        public string ExecutablePath { get; set; }
-        /// <summary>
-        /// Arguments to be passed to the executable program when it is started
-        /// </summary>
-        public string CommandLine { get; set; }
-        /// <summary>
-        /// Attributes and options passed to the process creation function call.
-        /// </summary>
-        public uint ProcessCreationFlags { get; set; }
-    }
-    public class CoreHookNativeConfig
-    {
-        /// <summary>
-        /// Library that initializes the .NET Core runtime (CoreCLR) and allows
-        /// loading and executing .NET Assemblies.
-        /// </summary>
-        public string HostLibrary { get; set; }
-        /// <summary>
-        /// Library that implements function intercept exports for the LocalHook class
-        /// such as DetourInstallHook.
-        /// </summary>
-        public string DetourLibrary { get; set; }
-        /// <summary>
-        /// Directory path which contains the main CoreCLR modules for hosting the runtime
-        /// such as CoreCLR and clrjit libraries.
-        /// </summary>
-        public string CoreCLRPath { get; set; }
-        /// <summary>
-        /// Directory path which contains the CoreCLR Assembly reference
-        /// runtime libraries such as System.Private.CoreLib.dll.
-        /// </summary>
-        public string CoreCLRLibrariesPath { get; set; }
-    }
     public class RemoteInjectorConfig : CoreHookNativeConfig
     {
         /// <summary>

--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjectorConfig.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjectorConfig.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CoreHook.BinaryInjection.RemoteInjection
 {
-    public class ProcessCreationConfig : ICreateProcessConfig
+    public class ProcessCreationConfig
     {
         /// <summary>
         /// Filepath to an executable program on the system that is to be launched.
@@ -16,32 +16,18 @@ namespace CoreHook.BinaryInjection.RemoteInjection
         /// </summary>
         public uint ProcessCreationFlags { get; set; }
     }
-    public class RemoteInjectorConfig : ICoreHookConfig, ICoreRunConfig, ICoreRunHostConfig, ICoreRootConfig, ICoreLoadConfig
+    public class CoreHookNativeConfig
     {
-        /// <summary>
-        /// Library that implements function intercept exports for the LocalHook class
-        /// such as DetourInstallHook.
-        /// </summary>
-        public string DetourLibrary { get; set; }
-        /// <summary>
-        /// .NET library that is loaded and executed inside the target process
-        /// by the bootstrap library after starting the .NET Core runtime.
-        /// </summary>
-        public string PayloadLibrary { get; set; }
         /// <summary>
         /// Library that initializes the .NET Core runtime (CoreCLR) and allows
         /// loading and executing .NET Assemblies.
         /// </summary>
         public string HostLibrary { get; set; }
         /// <summary>
-        /// Option to enable the logging module inside the HostLibrary.
+        /// Library that implements function intercept exports for the LocalHook class
+        /// such as DetourInstallHook.
         /// </summary>
-        public bool VerboseLog { get; set; }
-        /// <summary>
-        /// Library that resolves dependencies and passes arguments to
-        /// the .NET payload Assembly.
-        /// </summary>
-        public string CLRBootstrapLibrary { get; set; }
+        public string DetourLibrary { get; set; }
         /// <summary>
         /// Directory path which contains the main CoreCLR modules for hosting the runtime
         /// such as CoreCLR and clrjit libraries.
@@ -52,83 +38,28 @@ namespace CoreHook.BinaryInjection.RemoteInjection
         /// runtime libraries such as System.Private.CoreLib.dll.
         /// </summary>
         public string CoreCLRLibrariesPath { get; set; }
+    }
+    public class RemoteInjectorConfig : CoreHookNativeConfig
+    {
+        /// <summary>
+        /// .NET library that is loaded and executed inside the target process
+        /// by the bootstrap library after starting the .NET Core runtime.
+        /// </summary>
+        public string PayloadLibrary { get; set; }
+        /// <summary>
+        /// Option to enable the logging module inside the HostLibrary.
+        /// </summary>
+        public bool VerboseLog { get; set; }
+        /// <summary>
+        /// Library that resolves dependencies and passes arguments to
+        /// the .NET payload Assembly.
+        /// </summary>
+        public string CLRBootstrapLibrary { get; set; }
         /// <summary>
         /// The name of the pipe used for notifying the host process
         /// when the hooking plugin has been successfully loaded in
         /// the target process or if the injection process failed.
         /// </summary>
         public string InjectionPipeName { get; set; }
-    }
-    public interface ICreateProcessConfig
-    {
-        /// <summary>
-        /// Filepath to an executable program on the system that is to be launched.
-        /// </summary>
-        string ExecutablePath { get; set;  }
-        /// <summary>
-        /// Arguments to be passed to the executable program when it is started
-        /// </summary>
-        string CommandLine { get; set; }
-        /// <summary>
-        /// Attributes and options passed to the process creation function call.
-        /// </summary>
-        uint ProcessCreationFlags { get; set; }
-    }
-    public interface ICoreHookConfig
-    {
-        /// <summary>
-        /// Library that implements function intercept exports for the LocalHook class
-        /// such as DetourInstallHook.
-        /// </summary>
-        string DetourLibrary { get; set; }
-    }
-    public interface ICoreRunHostConfig
-    {
-        /// <summary>
-        /// Library that initializes the .NET Core runtime (CoreCLR) and allows
-        /// loading and executing .NET Assemblies.
-        /// </summary>
-        string HostLibrary { get; set; }
-    }
-    public class CoreHookNativeConfig : ICoreRunHostConfig, ICoreHookConfig, ICoreRootConfig
-    {
-        public string HostLibrary { get; set; }
-        public string DetourLibrary { get; set; }
-        public string CoreCLRPath { get; set; }
-        public string CoreCLRLibrariesPath { get ; set; }
-    }
-
-    public interface ICoreLoadConfig
-    {
-        /// <summary>
-        /// Library that resolves dependencies and passes arguments to
-        /// the .NET payload Assembly.
-        /// </summary>
-        string CLRBootstrapLibrary { get; set; }
-        /// <summary>
-        /// .NET library that is loaded and executed inside the target process
-        /// by the bootstrap library after starting the .NET Core runtime.
-        /// </summary>
-        string PayloadLibrary { get; set; }
-    }
-    public interface ICoreRootConfig
-    {
-        /// <summary>
-        /// Directory path which contains the main CoreCLR modules for hosting the runtime
-        /// such as CoreCLR and clrjit libraries.
-        /// </summary>
-        string CoreCLRPath { get; set; }
-        /// <summary>
-        /// Directory path which contains the CoreCLR Assembly reference
-        /// runtime libraries such as System.Private.CoreLib.dll.
-        /// </summary>
-        string CoreCLRLibrariesPath { get; set; }
-    }
-    public interface ICoreRunConfig
-    {
-        /// <summary>
-        /// Option to enable the logging module inside the HostLibrary.
-        /// </summary>
-        bool VerboseLog { get; set; }
     }
 }


### PR DESCRIPTION
Keep it simple by just using classes since none of the interfaces are being used. They can be re-implemented with interfaces if needed but since they don't contain any methods, using classes to hold the data seems fine until I learn how to handle it otherwise.