### PR TITLE
Add GitHub SourceLink support to the CoreHook main library v1.0.3

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -6,4 +6,5 @@ A lot of this project is based on the work of others who were willing to share t
 * [Christoph Husse and Justin Stenning](https://github.com/EasyHook/EasyHook/blob/master/LICENSE) - For the EasyHook library.
 * [Nate McMaster](https://github.com/natemcmaster) - For the build and publishing PowerShell scripts and the [.NET Core Plugins project](https://github.com/natemcmaster/DotNetCorePlugins).
 * [Powershell Team](https://github.com/PowerShell/PowerShell) - For the native pipe creation code.
+* [VFS for Git](https://github.com/Microsoft/VFSForGit) - For the IPC messaging code.
 * [ZenLulz (Jämes Ménétrey)](https://github.com/ZenLulz/MemorySharp) - For the MemorySharp library.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,9 @@
+# Credits
+
+A lot of this project is based on the work of others who were willing to share their knowledge.
+
+* [.NET Foundation Contributors](https://github.com/dotnet) - For the DependencyModel project.
+* [Christoph Husse and Justin Stenning](https://github.com/EasyHook/EasyHook/blob/master/LICENSE) - For the EasyHook library.
+* [Nate McMaster](https://github.com/natemcmaster) - For the build and publishing PowerShell scripts and the [.NET Core Plugins project](https://github.com/natemcmaster/DotNetCorePlugins).
+* [Powershell Team](https://github.com/PowerShell/PowerShell) - For the native pipe creation code.
+* [ZenLulz (Jämes Ménétrey)](https://github.com/ZenLulz/MemorySharp) - For the MemorySharp library.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
+
   <PropertyGroup Condition="'$(Configuration)' != ''">
     <ConfigurationGroup Condition="$(Configuration.EndsWith('Debug'))">Debug</ConfigurationGroup>
     <ConfigurationGroup Condition="$(Configuration.EndsWith('Release'))">Release</ConfigurationGroup>
@@ -8,24 +8,7 @@
     <CommonPath>$(SourceDir)Common\src</CommonPath>
     <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)Build/bin/</BinDir>
     <DefaultTargetFramework>netcoreapp2.2</DefaultTargetFramework>
-    <OutputDir>$(BinDir)$(Configuration)/$(DefaultTargetFramework)/$(Platform)/</OutputDir> 
-
-    <Authors>Thierry Bizimungu</Authors>
-    <Product>CoreHook</Product>
-    <Version>1.0.2</Version>
-    <PackageProjectUrl>https://github.com/unknownv2/CoreHook</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/unknownv2/CoreHook.git</RepositoryUrl>
-    <PackageLicenseUrl>https://github.com/unknownv2/CoreHook/blob/master/LICENSE</PackageLicenseUrl>
-    <Copyright>Copyright (c) 2018 Thierry Bizimungu</Copyright>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <RepositoryType>git</RepositoryType>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <DebugType>portable</DebugType>
-    <IsPackable>false</IsPackable>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>    
-    <Description>A library that simplifies intercepting application function calls using managed code and the .NET Core runtime.</Description>  
-
+    <OutputDir>$(BinDir)$(Configuration)/$(DefaultTargetFramework)/$(Platform)/</OutputDir>
   </PropertyGroup>
+
 </Project>

--- a/README.md
+++ b/README.md
@@ -209,11 +209,4 @@ Any contributions are all welcome! If you find any problems or want to add featu
 
 Licensed under the [MIT](LICENSE) License.
 
-## Credits
-
-A lot of this project is based on the work of others who were willing to share their knowledge.
-
-* [Christoph Husse and Justin Stenning](https://github.com/EasyHook/EasyHook/blob/master/LICENSE) - For the EasyHook library.
-* [dotnet Team](https://github.com/dotnet) - For the DependencyModel project.
-* [Nate McMaster](https://github.com/natemcmaster) - For the build and publishing PowerShell scripts and the [.NET Core Plugins project](https://github.com/natemcmaster/DotNetCorePlugins).
-* [ZenLulz (Jämes Ménétrey)](https://github.com/ZenLulz/MemorySharp) - For the MemorySharp library.
+## [Credits](/CREDITS.md)

--- a/build.ps1
+++ b/build.ps1
@@ -39,5 +39,5 @@ function exec([string]$_cmd) {
     }
 }
 
-exec dotnet build --configuration $Configuration '-warnaserror:CS1591' @MSBuildArgs
+exec dotnet build --configuration $Configuration @MSBuildArgs
 

--- a/examples/Uwp/CoreHook.Uwp.FileMonitor/Pipe/NamedPipeNative.cs
+++ b/examples/Uwp/CoreHook.Uwp.FileMonitor/Pipe/NamedPipeNative.cs
@@ -50,7 +50,7 @@ namespace CoreHook.Uwp.FileMonitor.Pipe
                 fullPipeName,
                 Interop.Kernel32.PipeOptions.PIPE_ACCESS_DUPLEX | Interop.Kernel32.FileOperations.FILE_FLAG_OVERLAPPED,
                 Interop.Kernel32.PipeOptions.PIPE_TYPE_BYTE | Interop.Kernel32.PipeOptions.PIPE_READMODE_BYTE,
-                255,
+                1,
                 65536,
                 65536,
                 0,

--- a/examples/Uwp/CoreHook.Uwp.FileMonitor/Program.cs
+++ b/examples/Uwp/CoreHook.Uwp.FileMonitor/Program.cs
@@ -18,29 +18,35 @@ namespace CoreHook.Uwp.FileMonitor
         /// The pipe name the FileMonitor RPC service communicates over between processes.
         /// </summary>
         private const string CoreHookPipeName = "UwpCoreHook";
+
         /// <summary>
         /// The directory containing the CoreHook modules to be loaded in the target process.
         /// </summary>
         private const string HookLibraryDirName = "Hook";
+
         /// <summary>
         /// The library to be injected into the target process and executed
         /// using it's 'Run' Method.
         /// </summary>
         private const string HookLibraryName = "CoreHook.Uwp.FileMonitor.Hook.dll";
+
         /// <summary>
         /// The name of the pipe used for notifying the host process
         /// if the hooking plugin has been loaded successfully in
         /// the target process or if loading failed.
         /// </summary>
         private const string InjectionPipeName = "UwpCoreHookInjection";
+
         /// <summary>
         /// Enable verbose logging to the console for the CoreCLR native host module.
         /// </summary>
         private const bool HostVerboseLog = false;
+
         /// <summary>
         /// Class that handles creating a named pipe server for communicating with the target process.
         /// </summary>
         private static readonly IPipePlatform PipePlatform = new Pipe.PipePlatform();
+
         /// <summary>
         /// Security Identifier representing ALL_APPLICATION_PACKAGES permission.
         /// </summary>

--- a/examples/Win32/CoreHook.FileMonitor/Program.cs
+++ b/examples/Win32/CoreHook.FileMonitor/Program.cs
@@ -15,25 +15,30 @@ namespace CoreHook.FileMonitor
         /// The pipe name the FileMonitor RPC service communicates over between processes.
         /// </summary>
         private const string CoreHookPipeName = "CoreHook";
+
         /// <summary>
         /// The directory containing the CoreHook modules to be loaded in the target process.
         /// </summary>
         private const string HookLibraryDirName = "Hook";
+
         /// <summary>
         /// The library to be injected into the target process and executed
         /// using the EntryPoint's 'Run' Method.
         /// </summary>
         private const string HookLibraryName = "CoreHook.FileMonitor.Hook.dll";
+
         /// <summary>
         /// The name of the pipe used for notifying the host process
         /// if the hooking plugin has been loaded successfully in
         /// the target process or if loading failed.
         /// </summary>
         private const string InjectionPipeName = "CoreHookInjection";
+
         /// <summary>
         /// Enable verbose logging to the console for the CoreCLR hosting module.
         /// </summary>
         private const bool HostVerboseLog = false;
+
         /// <summary>
         /// Class that handles creating a named pipe server for communicating with the target process.
         /// </summary>

--- a/examples/Win32/CoreHook.FileMonitor/Program.cs
+++ b/examples/Win32/CoreHook.FileMonitor/Program.cs
@@ -176,7 +176,6 @@ namespace CoreHook.FileMonitor
             string injectionLibrary,
             string injectionPipeName = InjectionPipeName)
         {
-            //ValidateFilePath(exePath);
             ValidateFilePath(injectionLibrary);
 
             if (Examples.Common.ModulesPathHelper.GetCoreLoadPaths(

--- a/src/CoreHook.BinaryInjection/Loader/PluginConfigurationArguments.cs
+++ b/src/CoreHook.BinaryInjection/Loader/PluginConfigurationArguments.cs
@@ -9,28 +9,34 @@ namespace CoreHook.BinaryInjection.Loader
     /// The loader transforms the arguments into 
     /// a managed configuration class and initializes the plugin.
     /// </summary>
-    public class PluginConfigurationArguments : ISerializableObject
+    internal class PluginConfigurationArguments : ISerializableObject
     {
-        public bool Is64BitProcess;
-        public IntPtr UserData;
-        public int UserDataSize;
+        private readonly bool _is64BitProcess;
+        private readonly IntPtr _userData;
+        private readonly int _userDataSize;
+
+        internal PluginConfigurationArguments(bool is64BitProcess, IntPtr userData, int userDataSize)
+        {
+            _is64BitProcess = is64BitProcess;
+            _userData = userData;
+            _userDataSize = userDataSize;
+        }
 
         public byte[] Serialize()
         {
             using (var ms = new MemoryStream())
             using (var writer = new BinaryWriter(ms))
             {
-                // Serialize information about the serialized class 
-                // data that is passed to the remote function.
-                if (Is64BitProcess)
+                // Store the address and size of the serialized plugin arguments.
+                if (_is64BitProcess)
                 {
-                    writer.Write(UserData.ToInt64());
-                    writer.Write(UserDataSize);
+                    writer.Write(_userData.ToInt64());
+                    writer.Write(_userDataSize);
                 }
                 else
                 {
-                    writer.Write(UserData.ToInt32());
-                    writer.Write(UserDataSize);
+                    writer.Write(_userData.ToInt32());
+                    writer.Write(_userDataSize);
                     // Add padding to fill the whole buffer.
                     writer.Write(new byte[4]);
                 }

--- a/src/CoreHook.BinaryInjection/Loader/PluginConfigurationArguments.cs
+++ b/src/CoreHook.BinaryInjection/Loader/PluginConfigurationArguments.cs
@@ -4,7 +4,12 @@ using CoreHook.BinaryInjection.Loader.Serialization;
 
 namespace CoreHook.BinaryInjection.Loader
 {
-    public class RemoteFunctionArguments : ISerializableObject
+    /// <summary>
+    /// Manages the arguments passed to the plugin loader.
+    /// The loader transforms the arguments into 
+    /// a managed configuration class and initializes the plugin.
+    /// </summary>
+    public class PluginConfigurationArguments : ISerializableObject
     {
         public bool Is64BitProcess;
         public IntPtr UserData;
@@ -15,8 +20,8 @@ namespace CoreHook.BinaryInjection.Loader
             using (var ms = new MemoryStream())
             using (var writer = new BinaryWriter(ms))
             {
-                // serialize information about the serialized class 
-                // data that is passed to the remote function
+                // Serialize information about the serialized class 
+                // data that is passed to the remote function.
                 if (Is64BitProcess)
                 {
                     writer.Write(UserData.ToInt64());
@@ -26,7 +31,7 @@ namespace CoreHook.BinaryInjection.Loader
                 {
                     writer.Write(UserData.ToInt32());
                     writer.Write(UserDataSize);
-                    // add padding to fill the whole buffer
+                    // Add padding to fill the whole buffer.
                     writer.Write(new byte[4]);
                 }
                 return ms.ToArray();

--- a/src/CoreHook.BinaryInjection/RemoteInjection/InjectionHelper.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/InjectionHelper.cs
@@ -38,7 +38,9 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                     }
                     break;
                 default:
+                {
                     throw new InvalidOperationException($"Message type {message.Header} is not supported");
+                }
             }
         }
 

--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
@@ -198,7 +198,7 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                         try
                         {
                             var process = GetProcessById(targetProcessId);
-                            var length = (int)pluginArgumentsStream.Length;
+                            var pluginArgumentsLength = (int)pluginArgumentsStream.Length;
 
                             using (var assemblyLoader = CreateAssemblyLoader(process))
                             {
@@ -228,12 +228,11 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                                     Arguments = new AssemblyFunctionArguments(
                                         pathConfig,
                                         CoreHookLoaderDelegate,
-                                        new PluginConfigurationArguments
-                                        {
-                                            Is64BitProcess = process.Is64Bit(),
-                                            UserData = assemblyLoader.CopyMemory(pluginArgumentsStream.GetBuffer(), length),
-                                            UserDataSize = length
-                                        }),
+                                        new PluginConfigurationArguments(
+                                            process.Is64Bit(),
+                                            assemblyLoader.CopyMemory(pluginArgumentsStream.GetBuffer(), pluginArgumentsLength),
+                                            pluginArgumentsLength)
+                                        ),
                                     FunctionName = new FunctionName { Module = remoteInjectorConfig.HostLibrary, Function = GetClrExecuteManagedFunctionName() }
                                 }, false);
 

--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
@@ -17,8 +17,8 @@ namespace CoreHook.BinaryInjection.RemoteInjection
     public static class RemoteInjector
     {
         /// <summary>
-        /// The .NET Assembly class that loads the .NET hooking library, resolves any references, and executes
-        /// the hooking library IEntryPoint.Run method.
+        /// The .NET Assembly class that loads the .NET plugin, resolves any references, and executes
+        /// the IEntryPoint.Run method for that plugin.
         /// </summary>
         private static readonly IAssemblyDelegate CoreHookLoaderDelegate =
                 new AssemblyDelegate(
@@ -181,7 +181,7 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                     // Initialize the arguments passed to the CoreHook plugin.
                     var remoteInfo = CreateRemoteInfo(localProcessId, remoteInfoFormatter, passThruArguments);
 
-                    using (var passThruStream = new MemoryStream())
+                    using (var pluginArgumentsStream = new MemoryStream())
                     {
                         // Serialize the plugin information such as the DLL path
                         // and the plugin arguments, which are copied to the remote process.
@@ -189,7 +189,7 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                             remoteInfo,
                             remoteInfoFormatter,
                             remoteInjectorConfig.PayloadLibrary,
-                            passThruStream,
+                            pluginArgumentsStream,
                             remoteInjectorConfig.InjectionPipeName);
 
                         // Inject the CoreCLR hosting module into the process, start the CoreCLR
@@ -198,7 +198,7 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                         try
                         {
                             var process = GetProcessById(targetProcessId);
-                            var length = (int)passThruStream.Length;
+                            var length = (int)pluginArgumentsStream.Length;
 
                             using (var assemblyLoader = CreateAssemblyLoader(process))
                             {
@@ -228,10 +228,10 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                                     Arguments = new AssemblyFunctionArguments(
                                         pathConfig,
                                         CoreHookLoaderDelegate,
-                                        new RemoteFunctionArguments
+                                        new PluginConfigurationArguments
                                         {
                                             Is64BitProcess = process.Is64Bit(),
-                                            UserData = assemblyLoader.CopyMemory(passThruStream.GetBuffer(), length),
+                                            UserData = assemblyLoader.CopyMemory(pluginArgumentsStream.GetBuffer(), length),
                                             UserDataSize = length
                                         }),
                                     FunctionName = new FunctionName { Module = remoteInjectorConfig.HostLibrary, Function = GetClrExecuteManagedFunctionName() }

--- a/src/CoreHook.Memory/MemoryHelper.Windows.cs
+++ b/src/CoreHook.Memory/MemoryHelper.Windows.cs
@@ -56,7 +56,7 @@ namespace CoreHook.Memory
                 new UIntPtr(0),
                 Interop.Kernel32.FreeType.Release))
             {
-                throw new Win32Exception($"Failed to free the memory region at {address:X16}.");
+                throw new Win32Exception($"Failed to free the memory region at {address.ToInt64():X16}.");
             }
         }
     }

--- a/src/CoreHook.Memory/Processes/ProcessManager.Windows.cs
+++ b/src/CoreHook.Memory/Processes/ProcessManager.Windows.cs
@@ -19,7 +19,7 @@ namespace CoreHook.Memory.Processes
 
         public void InjectBinary(string modulePath)
         {
-            ExecuteFuntion(Path.Combine(
+            ExecuteFunction(Path.Combine(
                              Environment.ExpandEnvironmentVariables("%Windir%"),
                              "System32",
                              "kernel32.dll"),
@@ -37,10 +37,10 @@ namespace CoreHook.Memory.Processes
         /// we allocated or return immediately and deallocate the memory in a separate call.</param>
         public IntPtr Execute(string module, string function, byte[] arguments, bool waitForThreadExit = true)
         {
-            return ExecuteFuntion(module, function, arguments, waitForThreadExit);
+            return ExecuteFunction(module, function, arguments, waitForThreadExit);
         }
 
-        private IntPtr ExecuteFuntion(string module, string function, byte[] arguments, bool waitForThreadExit = true)
+        private IntPtr ExecuteFunction(string module, string function, byte[] arguments, bool waitForThreadExit = true)
         {
             SafeWaitHandle remoteThread = null;
 
@@ -87,12 +87,12 @@ namespace CoreHook.Memory.Processes
         public IntPtr CopyToProcess(byte[] data, int? size)
         {
             int dataLen = size ?? data.Length;
-            IntPtr remoteAllocAddr = _memoryManager.Allocate(dataLen, 
+            IntPtr allocationAddress = _memoryManager.Allocate(dataLen, 
                 MemoryProtectionType.ReadWrite).Address;
 
-            _memoryManager.WriteMemory(remoteAllocAddr.ToInt64(), data);
+            _memoryManager.WriteMemory(allocationAddress.ToInt64(), data);
  
-            return remoteAllocAddr;
+            return allocationAddress;
         }
 
         public void Dispose()

--- a/src/CoreHook/CoreHook.csproj
+++ b/src/CoreHook/CoreHook.csproj
@@ -14,6 +14,14 @@
     <OutputPath>$(OutputDir)</OutputPath>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
+    <Optimize>true</Optimize>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/src/CoreHook/Directory.Build.props
+++ b/src/CoreHook/Directory.Build.props
@@ -1,0 +1,27 @@
+<Project>
+
+<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup Condition="'$(Configuration)' != ''">
+    <Authors>Thierry Bizimungu</Authors>
+    <Product>CoreHook</Product>
+    <Version>1.0.3</Version>
+    <PackageProjectUrl>https://github.com/unknownv2/CoreHook</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/unknownv2/CoreHook.git</RepositoryUrl>
+    <PackageLicenseUrl>https://github.com/unknownv2/CoreHook/blob/master/LICENSE</PackageLicenseUrl>
+    <Copyright>Copyright (c) 2018 Thierry Bizimungu</Copyright>  
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <RepositoryType>git</RepositoryType>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+    <IsPackable>true</IsPackable>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+    <Description>A library that simplifies intercepting application function calls using managed code and the .NET Core runtime.</Description>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+</Project>

--- a/src/CoreHook/Directory.Build.props
+++ b/src/CoreHook/Directory.Build.props
@@ -3,6 +3,7 @@
 <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup Condition="'$(Configuration)' != ''">
+    <DocumentationFile>$(BinDir)$(Configuration)/$(DefaultTargetFramework)/$(Platform)/$(MSBuildProjectName).xml</DocumentationFile>
     <Authors>Thierry Bizimungu</Authors>
     <Product>CoreHook</Product>
     <Version>1.0.3</Version>

--- a/src/CoreHook/HookAccessControl.cs
+++ b/src/CoreHook/HookAccessControl.cs
@@ -37,11 +37,11 @@ namespace CoreHook
 
             if (_handle == IntPtr.Zero)
             {
-                NativeAPI.DetourSetGlobalExclusiveACL(_acl, _acl.Length);
+                NativeApi.DetourSetGlobalExclusiveACL(_acl, _acl.Length);
             }
             else
             {
-                NativeAPI.DetourSetExclusiveACL(_acl, _acl.Length, _handle);
+                NativeApi.DetourSetExclusiveACL(_acl, _acl.Length, _handle);
             }
         }
 
@@ -59,11 +59,11 @@ namespace CoreHook
 
             if (_handle == IntPtr.Zero)
             {
-                NativeAPI.DetourSetGlobalInclusiveACL(_acl, _acl.Length);
+                NativeApi.DetourSetGlobalInclusiveACL(_acl, _acl.Length);
             }
             else
             {
-                NativeAPI.DetourSetInclusiveACL(_acl, _acl.Length, _handle);
+                NativeApi.DetourSetInclusiveACL(_acl, _acl.Length, _handle);
             }
         }
 

--- a/src/CoreHook/HookAccessControl.cs
+++ b/src/CoreHook/HookAccessControl.cs
@@ -5,7 +5,7 @@ namespace CoreHook
     /// <summary>
     /// Class used for managing the thread ACL of a hook.
     /// </summary>
-    public class HookAccessControl : IHookAccessControl
+    internal class HookAccessControl : IHookAccessControl
     {
         private static readonly int[] DefaultThreadACL = new int[0];
 
@@ -17,7 +17,7 @@ namespace CoreHook
 
         private int[] _acl = DefaultThreadACL;
 
-        public HookAccessControl(IntPtr handle)
+        internal HookAccessControl(IntPtr handle)
         {
             IsExclusive = handle == IntPtr.Zero;
             _handle = handle;

--- a/src/CoreHook/HookAccessControl.cs
+++ b/src/CoreHook/HookAccessControl.cs
@@ -7,7 +7,7 @@ namespace CoreHook
     /// </summary>
     internal class HookAccessControl : IHookAccessControl
     {
-        private static readonly int[] DefaultThreadACL = new int[0];
+        private static readonly int[] DefaultThreadAcl = new int[0];
 
         public bool IsExclusive { get; private set; }
 
@@ -15,7 +15,7 @@ namespace CoreHook
 
         private readonly IntPtr _handle;
 
-        private int[] _acl = DefaultThreadACL;
+        private int[] _acl = DefaultThreadAcl;
 
         internal HookAccessControl(IntPtr handle)
         {
@@ -33,7 +33,7 @@ namespace CoreHook
         {
             IsExclusive = true;
 
-            _acl = acl == null ? DefaultThreadACL : (int[])acl.Clone();
+            _acl = acl == null ? DefaultThreadAcl : (int[])acl.Clone();
 
             if (_handle == IntPtr.Zero)
             {
@@ -55,7 +55,7 @@ namespace CoreHook
         {
             IsExclusive = false;
 
-            _acl = acl == null ? DefaultThreadACL : (int[])acl.Clone();
+            _acl = acl == null ? DefaultThreadAcl : (int[])acl.Clone();
 
             if (_handle == IntPtr.Zero)
             {

--- a/src/CoreHook/HookFactory.cs
+++ b/src/CoreHook/HookFactory.cs
@@ -10,10 +10,10 @@ namespace CoreHook
         /// <summary>
         /// Create a managed hook.
         /// </summary>
-        /// <param name="targetFunction"></param>
-        /// <param name="detourFunction"></param>
-        /// <param name="callback"></param>
-        /// <returns></returns>
+        /// <param name="targetFunction">The target function address that will be detoured.</param>
+        /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
+        /// <param name="callback">A context object that can be accessed as <see cref="HookRuntimeInfo.Callback"/>.</param>
+        /// <returns>The handle to the function hook.</returns>
         public static IHook CreateHook(IntPtr targetFunction, Delegate detourFunction, object callback)
         {
             return LocalHook.Create(targetFunction, detourFunction, callback);
@@ -22,9 +22,9 @@ namespace CoreHook
         /// <summary>
         ///  Create an unmanaged hook.
         /// </summary>
-        /// <param name="targetFunction"></param>
-        /// <param name="detourFunction"></param>
-        /// <returns></returns>
+        /// <param name="targetFunction">The target function address that will be detoured.</param>
+        /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
+        /// <returns>The handle to the function hook.</returns>
         public static IHook CreateHook(IntPtr targetFunction, IntPtr detourFunction)
         {
             return LocalHook.CreateUnmanaged(targetFunction, detourFunction, IntPtr.Zero);
@@ -33,10 +33,10 @@ namespace CoreHook
         /// <summary>
         /// Create an unmanaged hook
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="targetFunction"></param>
-        /// <param name="detourFunction"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">The delegate type representing the detoured function signature.</typeparam>
+        /// <param name="targetFunction">The target function address that will be detoured.</param>
+        /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
+        /// <returns>The handle to the function hook.</returns>
         public static IHook<T> CreateHook<T>(IntPtr targetFunction, IntPtr detourFunction) where T : class
         {
             return LocalHook<T>.CreateUnmanaged(targetFunction, detourFunction, IntPtr.Zero);
@@ -45,11 +45,11 @@ namespace CoreHook
         /// <summary>
         /// Create a managed hook.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="targetFunction"></param>
-        /// <param name="detourFunction"></param>
-        /// <param name="callback"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">The delegate type representing the detoured function signature.</typeparam>
+        /// <param name="targetFunction">The target function address that will be detoured.</param>
+        /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
+        /// <param name="callback">A context object that can be accessed as <see cref="HookRuntimeInfo.Callback"/>.</param>
+        /// <returns>The handle to the function hook.</returns>
         public static IHook<T> CreateHook<T>(IntPtr targetFunction, T detourFunction, object callback = null) where T : class
         {
             return LocalHook<T>.Create(targetFunction, detourFunction as Delegate, callback);

--- a/src/CoreHook/HookFactory.cs
+++ b/src/CoreHook/HookFactory.cs
@@ -3,7 +3,7 @@
 namespace CoreHook
 {
     /// <summary>
-    /// Class for creating managed and unmanaged hooks.
+    /// Factory for creating managed and unmanaged hooks.
     /// </summary>
     public static class HookFactory
     {
@@ -20,7 +20,7 @@ namespace CoreHook
         }
 
         /// <summary>
-        ///  Create an unmanaged hook.
+        /// Create an unmanaged hook.
         /// </summary>
         /// <param name="targetFunction">The target function address that will be detoured.</param>
         /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
@@ -31,7 +31,7 @@ namespace CoreHook
         }
 
         /// <summary>
-        /// Create an unmanaged hook
+        /// Create an unmanaged hook.
         /// </summary>
         /// <typeparam name="T">The delegate type representing the detoured function signature.</typeparam>
         /// <param name="targetFunction">The target function address that will be detoured.</param>

--- a/src/CoreHook/HookRuntimeInfo.cs
+++ b/src/CoreHook/HookRuntimeInfo.cs
@@ -13,7 +13,7 @@ namespace CoreHook
         /// True if the current method was called from a detoured function.
         /// </summary>
         public static bool IsHandlerContext =>
-            NativeAPI.DetourBarrierGetCallback(out IntPtr _) == NativeAPI.STATUS_SUCCESS;
+            NativeApi.DetourBarrierGetCallback(out IntPtr _) == NativeApi.StatusSuccess;
 
         /// <summary>
         /// The user callback parameter passed to the hook class during creation.
@@ -28,7 +28,7 @@ namespace CoreHook
         {
             get
             {
-                NativeAPI.DetourBarrierGetCallback(out IntPtr callback);
+                NativeApi.DetourBarrierGetCallback(out IntPtr callback);
                 return callback == IntPtr.Zero ? null : GCHandle.FromIntPtr(callback).Target as IHook;
             }
         }

--- a/src/CoreHook/LocalHook.cs
+++ b/src/CoreHook/LocalHook.cs
@@ -128,7 +128,7 @@ namespace CoreHook
         /// <param name="targetFunction">The target function to install the detour at.</param>
         /// <param name="detourFunction">The hook handler which intercepts the target function.</param>
         /// <param name="callback">A context object that will be available for reference inside the detour.</param>
-        /// <returns></returns>
+        /// <returns>The handle to the function hook.</returns>
         public static LocalHook Create(IntPtr targetFunction, Delegate detourFunction, object callback)
         {
             var hook = new LocalHook
@@ -172,7 +172,7 @@ namespace CoreHook
         /// <param name="targetFunction">The target function to install the detour at.</param>
         /// <param name="detourFunction">The hook handler which intercepts the target function.</param>
         /// <param name="callback">A context object that will be available for reference inside the detour.</param>
-        /// <returns></returns>
+        /// <returns>The handle to the function hook.</returns>
         public static LocalHook CreateUnmanaged(IntPtr targetFunction, IntPtr detourFunction, IntPtr callback)
         {
             var hook = new LocalHook
@@ -269,6 +269,9 @@ namespace CoreHook
             }
         }
 
+        /// <summary>
+        /// Ensure the function hook is uninstalled and any held resources are freed.
+        /// </summary>
         ~LocalHook()
         {
             Dispose();
@@ -292,15 +295,13 @@ namespace CoreHook
         /// </summary>
         public T Target => TargetAddress.ToFunction<T>();
 
-        public bool EnableForCurrentThread => false;
-
         /// <summary>
         /// Installs an unmanaged hook using the pointer to a hook handler.
         /// </summary>
         /// <param name="targetFunction">The target function to install the detour at.</param>
         /// <param name="detourFunction">The hook handler which intercepts the target function.</param>
         /// <param name="callback">A context object that will be available for reference inside the detour.</param>
-        /// <returns></returns>
+        /// <returns>The handle to the function hook.</returns>
         public new static LocalHook<T> CreateUnmanaged(IntPtr targetFunction, IntPtr detourFunction, IntPtr callback)
         {
             var hook = new LocalHook<T>
@@ -343,7 +344,7 @@ namespace CoreHook
         /// <param name="targetFunction">The target function to install the detour at.</param>
         /// <param name="detourFunction">The hook handler which intercepts the target function.</param>
         /// <param name="callback">A context object that will be available for reference inside the detour.</param>
-        /// <returns></returns>
+        /// <returns>The handle to the function hook.</returns>
         public new static LocalHook<T> Create(IntPtr targetFunction, Delegate detourFunction, object callback)
         {
             var hook = new LocalHook<T>

--- a/src/CoreHook/LocalHook.cs
+++ b/src/CoreHook/LocalHook.cs
@@ -58,7 +58,7 @@ namespace CoreHook
                     throw new ObjectDisposedException(typeof(LocalHook).FullName);
                 }
 
-                NativeAPI.DetourGetHookBypassAddress(Handle, out IntPtr targetFunctionAddress);
+                NativeApi.DetourGetHookBypassAddress(Handle, out IntPtr targetFunctionAddress);
                 return targetFunctionAddress;
             }
         }
@@ -114,7 +114,7 @@ namespace CoreHook
                 throw new ArgumentNullException(function);
             }
 
-            IntPtr functionAddress = NativeAPI.DetourFindFunction(module, function);
+            IntPtr functionAddress = NativeApi.DetourFindFunction(module, function);
             if (functionAddress == IntPtr.Zero)
             {
                 throw new MissingMethodException($"The function {function} in module {module} was not found.");
@@ -145,7 +145,7 @@ namespace CoreHook
 
             try
             {
-                NativeAPI.DetourInstallHook(
+                NativeApi.DetourInstallHook(
                     targetFunction,
                     Marshal.GetFunctionPointerForDelegate(hook.DetourFunction),
                     GCHandle.ToIntPtr(hook.SelfHandle),
@@ -188,7 +188,7 @@ namespace CoreHook
 
             try
             {
-                NativeAPI.DetourInstallHook(
+                NativeApi.DetourInstallHook(
                     targetFunction,
                     detourFunction,
                     callback,
@@ -222,7 +222,7 @@ namespace CoreHook
 
             try
             {
-                NativeAPI.DetourInstallHook(
+                NativeApi.DetourInstallHook(
                     targetFunction,
                     detourFunction,
                     callback,
@@ -255,7 +255,7 @@ namespace CoreHook
                     _disposed = true;
 
                     // Uninstall the detour
-                    NativeAPI.DetourUninstallHook(Handle);
+                    NativeApi.DetourUninstallHook(Handle);
 
                     // Release the detour's resources
                     Marshal.FreeCoTaskMem(Handle);
@@ -317,7 +317,7 @@ namespace CoreHook
 
             try
             {
-                NativeAPI.DetourInstallHook(
+                NativeApi.DetourInstallHook(
                     targetFunction,
                     detourFunction,
                     callback,
@@ -361,7 +361,7 @@ namespace CoreHook
 
             try
             {
-                NativeAPI.DetourInstallHook(
+                NativeApi.DetourInstallHook(
                     targetFunction,
                     Marshal.GetFunctionPointerForDelegate(hook.DetourFunction),
                     GCHandle.ToIntPtr(hook.SelfHandle),
@@ -394,7 +394,7 @@ namespace CoreHook
                 throw new ObjectDisposedException(typeof(LocalHook<T>).FullName);
             }
 
-            NativeAPI.DetourIsThreadIntercepted(Handle, threadId, out bool isThreadIntercepted);
+            NativeApi.DetourIsThreadIntercepted(Handle, threadId, out bool isThreadIntercepted);
 
             return isThreadIntercepted;
         }

--- a/src/CoreHook/NativeImport.cs
+++ b/src/CoreHook/NativeImport.cs
@@ -300,8 +300,14 @@ namespace CoreHook
             string lpFunction);
     }
 
+    /// <summary>
+    /// APIs for calling into the native detouring module.
+    /// </summary>
     public static class NativeApi
     {
+        /// <summary>
+        /// Determine if the current application is 32 or 64 bit.
+        /// </summary>
         public static readonly bool Is64Bit = IntPtr.Size == 8;
 
         internal const int StatusSuccess = 0;

--- a/src/CoreHook/NativeImport.cs
+++ b/src/CoreHook/NativeImport.cs
@@ -29,12 +29,6 @@ namespace CoreHook
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
         public static extern int DetourWaitForPendingRemovals();
 
-
-        /*
-            Setup the ACLs after hook installation. Please note that every
-            hook starts suspended. You will have to set a proper ACL to
-            make it active!
-        */
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
         public static extern int DetourSetInclusiveACL(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
@@ -67,13 +61,6 @@ namespace CoreHook
                     IntPtr handle,
                     int threadId,
                     out bool result);
-
-        /*
-            The following barrier methods are meant to be used in hook handlers only!
-
-            They will all fail with STATUS_NOT_SUPPORTED if called outside a
-            valid hook handler...
-        */
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
         public static extern int DetourBarrierGetCallback(out IntPtr returnValue);
@@ -191,12 +178,7 @@ namespace CoreHook
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
         public static extern int DetourWaitForPendingRemovals();
-        
-        /*
-            Setup the ACLs after hook installation. Please note that every
-            hook starts suspended. You will have to set a proper ACL to
-            make it active!
-        */
+       
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
         public static extern int DetourSetInclusiveACL(
                     [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]
@@ -230,16 +212,8 @@ namespace CoreHook
                     int threadId,
                     out bool result);
 
-        /*
-            The following barrier methods are meant to be used in hook handlers only!
-
-            They will all fail with STATUS_NOT_SUPPORTED if called outside a
-            valid hook handler...
-        */
-
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
         public static extern int DetourBarrierGetCallback(out IntPtr returnValue);
-
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
         public static extern int DetourBarrierGetReturnAddress(out IntPtr returnValue);
@@ -258,7 +232,6 @@ namespace CoreHook
 
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall)]
         public static extern int DetourBarrierGetCallingModule(out IntPtr returnValue);
-
           
         [DllImport(DllName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public static extern int DetourGetHookBypassAddress(IntPtr handle, out IntPtr address);
@@ -327,76 +300,24 @@ namespace CoreHook
             string lpFunction);
     }
 
-    public static class NativeAPI
+    public static class NativeApi
     {
         public static readonly bool Is64Bit = IntPtr.Size == 8;
 
-        [DllImport("kernel32.dll")]
-        public static extern short RtlCaptureStackBackTrace(
-            int framesToSkip,
-            int framesToCapture,
-            IntPtr backTrace,
-            IntPtr backTraceHash);
+        internal const int StatusSuccess = 0;
 
-        public const int STATUS_SUCCESS = unchecked((int)0);
-        public const int STATUS_INVALID_PARAMETER = unchecked((int)0xC000000DL);
-        public const int STATUS_INVALID_PARAMETER_1 = unchecked((int)0xC00000EFL);
-        public const int STATUS_INVALID_PARAMETER_2 = unchecked((int)0xC00000F0L);
-        public const int STATUS_INVALID_PARAMETER_3 = unchecked((int)0xC00000F1L);
-        public const int STATUS_INVALID_PARAMETER_4 = unchecked((int)0xC00000F2L);
-        public const int STATUS_INVALID_PARAMETER_5 = unchecked((int)0xC00000F3L);
-        public const int STATUS_NOT_SUPPORTED = unchecked((int)0xC00000BBL);
-
-        public const int STATUS_INTERNAL_ERROR = unchecked((int)0xC00000E5L);
-        public const int STATUS_INSUFFICIENT_RESOURCES = unchecked((int)0xC000009AL);
-        public const int STATUS_BUFFER_TOO_SMALL = unchecked((int)0xC0000023L);
-        public const int STATUS_NO_MEMORY = unchecked((int)0xC0000017L);
-        public const int STATUS_WOW_ASSERTION = unchecked((int)0xC0009898L);
-        public const int STATUS_ACCESS_DENIED = unchecked((int)0xC0000022L);
-
-        private static bool IsArchitectureArm()
-        {
-            var arch = RuntimeInformation.ProcessArchitecture;
-            return arch == Architecture.Arm || arch == Architecture.Arm64;
-        }
-
-        private static string ComposeString()
-        {
-            return "ERROR";
-        }
-
-        internal static void Force(int errorCode)
+        internal static void HandleErrorCode(int errorCode)
         {
             switch (errorCode)
             {
-                case STATUS_SUCCESS: return;
-                case STATUS_INVALID_PARAMETER: throw new ArgumentException("STATUS_INVALID_PARAMETER: " + ComposeString());
-                case STATUS_INVALID_PARAMETER_1: throw new ArgumentException("STATUS_INVALID_PARAMETER_1: " + ComposeString());
-                case STATUS_INVALID_PARAMETER_2: throw new ArgumentException("STATUS_INVALID_PARAMETER_2: " + ComposeString());
-                case STATUS_INVALID_PARAMETER_3: throw new ArgumentException("STATUS_INVALID_PARAMETER_3: " + ComposeString());
-                case STATUS_INVALID_PARAMETER_4: throw new ArgumentException("STATUS_INVALID_PARAMETER_4: " + ComposeString());
-                case STATUS_INVALID_PARAMETER_5: throw new ArgumentException("STATUS_INVALID_PARAMETER_5: " + ComposeString());
-                case STATUS_NOT_SUPPORTED: throw new NotSupportedException("STATUS_NOT_SUPPORTED: " + ComposeString());
-                case STATUS_INTERNAL_ERROR: throw new ApplicationException("STATUS_INTERNAL_ERROR: " + ComposeString());
-                case STATUS_INSUFFICIENT_RESOURCES: throw new InsufficientMemoryException("STATUS_INSUFFICIENT_RESOURCES: " + ComposeString());
-                case STATUS_BUFFER_TOO_SMALL: throw new ArgumentException("STATUS_BUFFER_TOO_SMALL: " + ComposeString());
-                case STATUS_NO_MEMORY: throw new OutOfMemoryException("STATUS_NO_MEMORY: " + ComposeString());
-                case STATUS_WOW_ASSERTION: throw new OutOfMemoryException("STATUS_WOW_ASSERTION: " + ComposeString());
-                case STATUS_ACCESS_DENIED: throw new AccessViolationException("STATUS_ACCESS_DENIED: " + ComposeString());
-
-                default: throw new ApplicationException("Unknown error code (" + errorCode + "): " + ComposeString());
-            }
-        }
-
-        public static int RtlGetLastError()
-        {
-            if (Is64Bit)
-            {
-                return NativeApi64.RtlGetLastError();
-            }
-            else
-            {
-                return NativeApi32.RtlGetLastError();
+                case StatusSuccess:
+                {
+                    return;
+                }
+                default:
+                {
+                    throw new ApplicationException($"Unknown error {errorCode}.");
+                }
             }
         }
 
@@ -420,12 +341,12 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourInstallHook(entryPoint, hookProcedure, callback, handle));
+                HandleErrorCode(NativeApi64.DetourInstallHook(entryPoint, hookProcedure, callback, handle));
             }
             else
             {
 
-                Force(NativeApi32.DetourInstallHook(entryPoint, hookProcedure, callback, handle));
+                HandleErrorCode(NativeApi32.DetourInstallHook(entryPoint, hookProcedure, callback, handle));
             }
         }
 
@@ -433,11 +354,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourUninstallHook(refHandle));
+                HandleErrorCode(NativeApi64.DetourUninstallHook(refHandle));
             }
             else
             {
-                Force(NativeApi32.DetourUninstallHook(refHandle));
+                HandleErrorCode(NativeApi32.DetourUninstallHook(refHandle));
             }
         }
 
@@ -446,11 +367,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourWaitForPendingRemovals());
+                HandleErrorCode(NativeApi64.DetourWaitForPendingRemovals());
             }
             else
             {
-                Force(NativeApi32.DetourWaitForPendingRemovals());
+                HandleErrorCode(NativeApi32.DetourWaitForPendingRemovals());
             }
         }
 
@@ -461,11 +382,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourIsThreadIntercepted(handle, threadId, out result));
+                HandleErrorCode(NativeApi64.DetourIsThreadIntercepted(handle, threadId, out result));
             }
             else
             {
-                Force(NativeApi32.DetourIsThreadIntercepted(handle, threadId, out result));
+                HandleErrorCode(NativeApi32.DetourIsThreadIntercepted(handle, threadId, out result));
             }
         }
 
@@ -476,11 +397,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourSetInclusiveACL(threadIdList, threadCount, handle));
+                HandleErrorCode(NativeApi64.DetourSetInclusiveACL(threadIdList, threadCount, handle));
             }
             else
             {
-                Force(NativeApi32.DetourSetInclusiveACL(threadIdList, threadCount, handle));
+                HandleErrorCode(NativeApi32.DetourSetInclusiveACL(threadIdList, threadCount, handle));
             }
         }
 
@@ -491,11 +412,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourSetExclusiveACL(threadIdList, threadCount, handle));
+                HandleErrorCode(NativeApi64.DetourSetExclusiveACL(threadIdList, threadCount, handle));
             }
             else
             {
-                Force(NativeApi32.DetourSetExclusiveACL(threadIdList, threadCount, handle));
+                HandleErrorCode(NativeApi32.DetourSetExclusiveACL(threadIdList, threadCount, handle));
             }
         }
 
@@ -505,11 +426,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourSetGlobalInclusiveACL(threadIdList, threadCount));
+                HandleErrorCode(NativeApi64.DetourSetGlobalInclusiveACL(threadIdList, threadCount));
             }
             else
             {
-                Force(NativeApi32.DetourSetGlobalInclusiveACL(threadIdList, threadCount));
+                HandleErrorCode(NativeApi32.DetourSetGlobalInclusiveACL(threadIdList, threadCount));
             }
         }
 
@@ -519,11 +440,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourSetGlobalExclusiveACL(threadIdList, threadCount));
+                HandleErrorCode(NativeApi64.DetourSetGlobalExclusiveACL(threadIdList, threadCount));
             }
             else
             {
-                Force(NativeApi32.DetourSetGlobalExclusiveACL(threadIdList, threadCount));
+                HandleErrorCode(NativeApi32.DetourSetGlobalExclusiveACL(threadIdList, threadCount));
             }
         }
 
@@ -532,11 +453,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourBarrierGetCallingModule(out returnValue));
+                HandleErrorCode(NativeApi64.DetourBarrierGetCallingModule(out returnValue));
             }
             else
             {
-                Force(NativeApi32.DetourBarrierGetCallingModule(out returnValue));
+                HandleErrorCode(NativeApi32.DetourBarrierGetCallingModule(out returnValue));
             }
         }
 
@@ -556,11 +477,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourBarrierGetReturnAddress(out returnValue));
+                HandleErrorCode(NativeApi64.DetourBarrierGetReturnAddress(out returnValue));
             }
             else
             {
-                Force(NativeApi32.DetourBarrierGetReturnAddress(out returnValue));
+                HandleErrorCode(NativeApi32.DetourBarrierGetReturnAddress(out returnValue));
             }
         }
 
@@ -568,11 +489,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourBarrierGetAddressOfReturnAddress(out returnValue));
+                HandleErrorCode(NativeApi64.DetourBarrierGetAddressOfReturnAddress(out returnValue));
             }
             else
             {
-                Force(NativeApi32.DetourBarrierGetAddressOfReturnAddress(out returnValue));
+                HandleErrorCode(NativeApi32.DetourBarrierGetAddressOfReturnAddress(out returnValue));
             }
         }
 
@@ -580,11 +501,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourBarrierBeginStackTrace(out backup));
+                HandleErrorCode(NativeApi64.DetourBarrierBeginStackTrace(out backup));
             }
             else
             {
-                Force(NativeApi32.DetourBarrierBeginStackTrace(out backup));
+                HandleErrorCode(NativeApi32.DetourBarrierBeginStackTrace(out backup));
             }
         }
 
@@ -592,11 +513,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourBarrierCallStackTrace(backup, maxCount, out outMaxCount));
+                HandleErrorCode(NativeApi64.DetourBarrierCallStackTrace(backup, maxCount, out outMaxCount));
             }
             else
             {
-                Force(NativeApi32.DetourBarrierCallStackTrace(backup, maxCount, out outMaxCount));
+                HandleErrorCode(NativeApi32.DetourBarrierCallStackTrace(backup, maxCount, out outMaxCount));
             }
 
         }
@@ -604,11 +525,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourBarrierEndStackTrace(backup));
+                HandleErrorCode(NativeApi64.DetourBarrierEndStackTrace(backup));
             }
             else
             {
-                Force(NativeApi32.DetourBarrierEndStackTrace(backup));
+                HandleErrorCode(NativeApi32.DetourBarrierEndStackTrace(backup));
             }
         }
 
@@ -616,11 +537,11 @@ namespace CoreHook
         {
             if (Is64Bit)
             {
-                Force(NativeApi64.DetourGetHookBypassAddress(handle, out address));
+                HandleErrorCode(NativeApi64.DetourGetHookBypassAddress(handle, out address));
             }
             else
             {
-                Force(NativeApi32.DetourGetHookBypassAddress(handle, out address));
+                HandleErrorCode(NativeApi32.DetourGetHookBypassAddress(handle, out address));
             }
 
         }


### PR DESCRIPTION
Define the build properties and references required to build the NuGet package that adds the GitHub SourceLink support for version 1.0.3 of the library.

* Refactor BinaryInjection class to simplify it.
* Rename the plugin configuration arguments class to make it clearer what it does.
* Limit the number of max connections to the IPC named pipe servers to 1 since that is all we need.
* Fixing typos and other renaming of variables for better readability.
* Add summaries for the public CoreHook classes and functions for using with the NuGet package.