### PR TITLE
Implemented Bleak to handle DLL Injection

### DIFF
--- a/src/CoreHook.Memory/CoreHook.Memory.csproj
+++ b/src/CoreHook.Memory/CoreHook.Memory.csproj
@@ -69,4 +69,7 @@
       <Link>Common\Interop\Windows\psapi\Interop.EnumProcessModulesEx.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Bleak" Version="1.2.2" />
+  </ItemGroup>
 </Project>

--- a/src/CoreHook.Memory/IProcess.cs
+++ b/src/CoreHook.Memory/IProcess.cs
@@ -5,6 +5,9 @@ namespace CoreHook.Memory
     public interface IProcess
     {
         System.Diagnostics.Process ProcessHandle { get; }
+
+        int ProcessId { get; }
+
         SafeProcessHandle SafeHandle { get; }
     }
 }

--- a/src/CoreHook.Memory/ManagedProcess.cs
+++ b/src/CoreHook.Memory/ManagedProcess.cs
@@ -8,6 +8,7 @@ namespace CoreHook.Memory
     {
         public Process ProcessHandle { get; }
         public SafeProcessHandle SafeHandle { get; }
+        public int ProcessId { get; }
 
         private const int DefaultProcessAccess =
                 Interop.Advapi32.ProcessOptions.PROCESS_CREATE_THREAD |
@@ -20,12 +21,14 @@ namespace CoreHook.Memory
         {
             ProcessHandle = process;
             SafeHandle = GetProcessHandle(process.Id, access);
+            ProcessId = process.Id;
         }
 
         public ManagedProcess(int processId, int access)
         {
             SafeHandle = GetProcessHandle(processId, access);
             ProcessHandle = Process.GetProcessById(processId);
+            ProcessId = processId;
         }
 
         private SafeProcessHandle GetProcessHandle(int processId, int access)


### PR DESCRIPTION
So I went ahead and added my library to replace the code that you use to inject a DLL.

You will notice that I didn't actually remove / rewrite the underlying function ExecuteFunction as I noticed it was being to used to call .net dll functions.

Let me know if this works. I didn't realise that you were dealing with calling .net functions from DLL's as well (I have a library in the works for doing this but it's no where near finished) so I couldn't use my library to replace the entire functionality.