### PR TITLE
Update project to use the coreload host module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CoreHook
 
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![NuGet](https://img.shields.io/nuget/v/CoreHook.svg)](https://www.nuget.org/packages/CoreHook)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
+[![NuGet](https://img.shields.io/nuget/v/CoreHook.svg?style=flat-square&colorB=f97356)](https://www.nuget.org/packages/CoreHook)
 
 A library that simplifies intercepting application function calls using managed code and the .NET Core runtime. 
 
@@ -29,7 +29,6 @@ Inspired and based on the great [EasyHook](https://github.com/EasyHook/EasyHook)
 | AppVeyor        | Windows     | [![Build status](https://ci.appveyor.com/api/projects/status/kj3n6vwax0ds9k2k?svg=true)](https://ci.appveyor.com/project/unknownv2/corehook)                                    |
 | Azure Pipelines | Linux, Windows     | [![Build Status](https://unknowndev.visualstudio.com/CoreHook/_apis/build/status/CoreHook/CoreHook)](https://unknowndev.visualstudio.com/CoreHook/_build/latest?definitionId=2) |
 | Travis CI       | Linux              | [![Build Status](https://travis-ci.com/unknownv2/CoreHook.svg?branch=master)](https://travis-ci.com/unknownv2/CoreHook)                                                         |
-
 
 ## Features
 * Intercept public API functions such as `CreateFile`

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ CoreHook supports application function call interception on various architecture
 ### Windows
 
 The native hosting module requires either a global `dotnet.runtimeconfig.json` file or a `CoreHook.CoreLoad.runtimeconfig.json` file (located next to `CoreHook.CoreLoad.dll` in the CoreHook output directory) to initialize CoreCLR. The `runtimeconfig` file must contain the framework information to be hosted in the target application.
-You can find an example of the configuration file in your .NET Core SDK installation directory, such as `C:\Program Files\dotnet\sdk\2.2.100\dotnet.runtimeconfig.json`.
 
 An example of the `runtimeconfig.json` configuration file is:
 ```json
@@ -116,7 +115,7 @@ To use CoreHook, first create a `dotnet.runtimeconfig.json` file and save it to 
 
 The runtime configuration file should look like the one below, where `additionalProbingPaths` contains file paths the host module can check for additional dependencies.
 
-**Either replace `user_name` with your local computer account name or modify the paths to point to where your NuGet packages are installed.**
+**Notice: Either replace `user_name` with your local computer user name or modify the paths to point to where your NuGet packages are installed.**
 
 ```json
 {
@@ -135,11 +134,9 @@ The runtime configuration file should look like the one below, where `additional
 }
 ```
 
-
-
 Set the environment variables for the `x86` and `x64` applications to the directory of the runtime configuration file. This allows you to have different configuration files for the runtime for `32-bit` and `64-bit` applications.
 
-For example (validate the paths if you have another installation directory or drive):
+For example (if you saved the file another installation directory or drive, make sure to use that path):
 
  * Set `CORE_ROOT_32` to `C:\CoreHook` for `32-bit` applications.
  

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ CoreHook supports application function call interception on various architecture
 
 If you are building the CoreHook project (for example, with `dotnet build`) and not publishing it, you must setup the project configuration as described below.
 
-#### Configuration
+#### Project Configuration
 
 The native hosting module requires either: 1) A global `dotnet.runtimeconfig.json` file or 2) a local `CoreHook.CoreLoad.runtimeconfig.json` file
 (located next to `CoreHook.CoreLoad.dll` in the CoreHook output directory) to initialize CoreCLR. The host module will first attempt to
@@ -147,7 +147,10 @@ set CORE_ROOT_32=C:\CoreHook
 
 Then, you can either open the `CoreHook` solution in `Visual Studio` or run `dotnet build` to build the library and the examples.
 
-Finally, build or download the binary releases (in ZIP files) from [CoreHook.Hooking](https://github.com/unknownv2/CoreHook.Hooking) and [CoreHook.Host](https://github.com/unknownv2/CoreHook.Host). Place the `coreload32.dll (X86, ARM)` and/or `coreload64.dll (X64, ARM64)` binaries in the output directory of your program. Then, place the `corehook32.dll (X86, ARM)` and/or `corehook64.dll (X64, ARM64)` binaries in the same output directory. These are all of the required files for using the examples above. 
+#### Installing Dependencies
+
+Build or download the binary releases from [CoreHook.Hooking](https://github.com/unknownv2/CoreHook.Hooking) and [CoreHook.Host](https://github.com/unknownv2/CoreHook.Host). You can use [download-deps](/download-deps.cmd) script, which downloads the latest binary releases to a folder called `deps` in the root of the project. 
+Place the `coreload32.dll (X86, ARM)` and/or `coreload64.dll (X64, ARM64)` binaries in the output directory of your program. Then, place the `corehook32.dll (X86, ARM)` and/or `corehook64.dll (X64, ARM64)` binaries in the same output directory. These are all of the required files for using the examples above. 
 
 You can then start the program you built above.
 

--- a/README.md
+++ b/README.md
@@ -82,26 +82,80 @@ CoreHook supports application function call interception on various architecture
 
 ### Windows
 
-First, set the environment variables for the `x86` and `x64` applications to the installation folder of your desired dotnet runtime. 
+The native hosting module requires either a global `dotnet.runtimeconfig.json` file or a `CoreHook.CoreLoad.runtimeconfig.json` file (located next to `CoreHook.CoreLoad.dll` in the CoreHook output directory) to initialize CoreCLR. The `runtimeconfig` file must contain the framework information to be hosted in the target application.
+You can find an example of the configuration file in your .NET Core SDK installation directory, such as `C:\Program Files\dotnet\sdk\2.2.100\dotnet.runtimeconfig.json`.
 
-Using the `.NET Core 2.2` runtime as an example (validate the paths if you have another installation directory or drive):
+An example of the `runtimeconfig.json` configuration file is:
+```json
+{
+  "runtimeOptions": {
+    "tfm": "netcoreapp2.2",
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "2.2.0"
+    }
+  }
+}
+```
 
- * Set `CORE_ROOT_32` to `C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App\2.2.0` for `32-bit` applications.
+You can also set additional probing paths for the host module to search for dependencies such as NuGet packages with a `CoreHook.CoreLoad.runtimeconfig.dev.json` file.
+
+```json
+{
+  "runtimeOptions": {
+    "additionalProbingPaths": [
+      "C:\\Users\\Thierry\\.dotnet\\store\\|arch|\\|tfm|",
+      "C:\\Users\\Thierry\\.nuget\\packages",
+      "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder"
+    ]
+  }
+}
+```
+
+To use CoreHook, first create a `dotnet.runtimeconfig.json` file and save it to a folder. This will be the global configuration file that will be used by CoreHook to initialize the runtime in the target processs. In this example, our file is at `C:\CoreHook\dotnet.runtimeconfig.json`.
+
+The runtime configuration file should look like the one below, where `additionalProbingPaths` contains file paths the host module can check for additional dependencies.
+
+**Either replace `user_name` with your local computer account name or modify the paths to point to where your NuGet packages are installed.**
+
+```json
+{
+  "runtimeOptions": {
+    "tfm": "netcoreapp2.2",
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "2.2.0"
+    },
+    "additionalProbingPaths": [
+      "C:\\Users\\user_name\\.dotnet\\store\\|arch|\\|tfm|",
+      "C:\\Users\\user_name\\.nuget\\packages",
+      "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder"
+    ]
+  }
+}
+```
+
+
+
+Set the environment variables for the `x86` and `x64` applications to the directory of the runtime configuration file. This allows you to have different configuration files for the runtime for `32-bit` and `64-bit` applications.
+
+For example (validate the paths if you have another installation directory or drive):
+
+ * Set `CORE_ROOT_32` to `C:\CoreHook` for `32-bit` applications.
  
- * Set `CORE_ROOT_64` to `C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.2.0` for `64-bit` applications.
+ * Set `CORE_ROOT_64` to `C:\CoreHook` for `64-bit` applications.
 
-You can run the following commmands to set the environment variables for your user account, and they will be set for the next command prompt or the next program you open, such as Visual Studio:
 
 ```ps
-setx CORE_ROOT_64 "C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.2.0"
-setx CORE_ROOT_32 "C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App\2.2.0"
+setx CORE_ROOT_64 "C:\CoreHook"
+setx CORE_ROOT_32 "C:\CoreHook"
 ```
 
 Or set them for the current command prompt session with:
 
 ```
-set CORE_ROOT_64=C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.2.0
-set CORE_ROOT_32=C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App\2.2.0
+set CORE_ROOT_64=C:\CoreHook
+set CORE_ROOT_32=C:\CoreHook
 ```
 
 Then, you can either open the `CoreHook` solution in `Visual Studio` or run `dotnet build` to build the library and the examples.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you are building the CoreHook project (for example, with `dotnet build`) and 
 
 The native hosting module requires either: 1) A global `dotnet.runtimeconfig.json` file or 2) a local `CoreHook.CoreLoad.runtimeconfig.json` file
 (located next to `CoreHook.CoreLoad.dll` in the CoreHook output directory) to initialize CoreCLR. The host module will first attempt to
-use the global configuration file if it exists, then it will check for a local configuration file, and finally it will use the directory of the `CoreHook.CoreLoad.dll` assembly for resolving dependencies.
+use the local configuration file, then it will check for the the global configuration file and use that if it exists, and finally it will use the directory of the `CoreHook.CoreLoad.dll` assembly for resolving dependencies.
 
 The `runtimeconfig` file must contain the framework information for hosting .NET Core in the target application.
 When you build any .NET Core application, these files are generated to the output directory. [For more information on the
@@ -95,37 +95,7 @@ configuration options, see here](https://github.com/dotnet/cli/blob/master/Docum
 
 You can use the `CoreHook.FileMonitor.runtimeconfig.json` and `CoreHook.FileMonitor.runtimeconfig.dev.json` files found in your build output directory as references for creating the global or local configuration files.
 
-An example of the contents of a `runtimeconfig.json` configuration file is:
-```json
-{
-  "runtimeOptions": {
-    "tfm": "netcoreapp2.2",
-    "framework": {
-      "name": "Microsoft.NETCore.App",
-      "version": "2.2.0"
-    }
-  }
-}
-```
-
-You can also set additional probing paths for the host module to search for dependencies such as NuGet packages by creating a separate `CoreHook.CoreLoad.runtimeconfig.dev.json` file, which should look like:
-
-```json
-{
-  "runtimeOptions": {
-    "additionalProbingPaths": [
-      "C:\\Users\\<user>\\.dotnet\\store\\|arch|\\|tfm|",
-      "C:\\Users\\<user>\\.nuget\\packages",
-      "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder"
-    ]
-  }
-}
-```
-
-#### Global Configuration
-To use CoreHook, first create a `dotnet.runtimeconfig.json` file and save it to a folder. This will be the global configuration file the project uses to initialize the runtime in the target processs. In this example, our file is saved at `C:\CoreHook\dotnet.runtimeconfig.json`.
-
-The runtime configuration file should look like the one below, where `additionalProbingPaths` contains file paths the host module can check for additional dependencies.
+The runtime configuration file should look like the one below, where `additionalProbingPaths` contains file paths the host module can check for additional dependencies. This guide assumes you have installed the `2.2` runtime or SDK for both x86 and x64 architectures.
 
 **Notice: Either replace `<user>` with your local computer user name or modify the paths to point to where your NuGet packages are installed. Take a look at `CoreHook.FileMonitor.runtimeconfig.dev.json` in the output directory to find your paths.**
 
@@ -146,10 +116,17 @@ The runtime configuration file should look like the one below, where `additional
 }
 ```
 
-Set the environment variables for the `x86` and `x64` applications to the directory of the runtime configuration file. This allows you to have different configuration files for `32-bit` and `64-bit` applications. 
-This guide assumes you have installed the `2.2` runtime for both architectures.
+#### Local Configuration
 
-For example (if you saved the file another installation directory or drive, make sure to use that path):
+To use a local configuration, create a file with the contents described above called `CoreHook.CoreLoad.runtimeconfig.json` and save it to the project output directory where `CoreHook.CoreLoad.dll` is located.
+
+#### Global Configuration
+
+To use a global configuration, first create a `dotnet.runtimeconfig.json` file with the contents described above and save it to a folder. This will be the global configuration file the project uses to initialize the runtime in the target processs. In this example, our file is saved at `C:\CoreHook\dotnet.runtimeconfig.json`.
+
+Set the environment variables for the `x86` and `x64` applications to the directory of the runtime configuration file. This allows you to have different configuration files for `32-bit` and `64-bit` applications. 
+
+For example (if you saved the file another installation directory or drive, make sure to use that path instead):
 
  * Set `CORE_ROOT_32` to `C:\CoreHook` for `32-bit` applications.
  

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ set CORE_ROOT_32=C:\CoreHook
 
 Then, you can either open the `CoreHook` solution in `Visual Studio` or run `dotnet build` to build the library and the examples.
 
-Finally, build or download the binary releases (in ZIP files) from [CoreHook.Hooking](https://github.com/unknownv2/CoreHook.Hooking) and [CoreHook.Host](https://github.com/unknownv2/CoreHook.Host). Place the `corerundll32.dll (X86, ARM)` and/or `corerundll64.dll (X64, ARM64)` binaries in the output directory of your program. Then, place the `corehook32.dll (X86, ARM)` and/or `corehook64.dll (X64, ARM64)` binaries in the same output directory. These are all of the required files for using the examples above. 
+Finally, build or download the binary releases (in ZIP files) from [CoreHook.Hooking](https://github.com/unknownv2/CoreHook.Hooking) and [CoreHook.Host](https://github.com/unknownv2/CoreHook.Host). Place the `coreload32.dll (X86, ARM)` and/or `coreload64.dll (X64, ARM64)` binaries in the output directory of your program. Then, place the `corehook32.dll (X86, ARM)` and/or `corehook64.dll (X64, ARM64)` binaries in the same output directory. These are all of the required files for using the examples above. 
 
 You can then start the program you built above.
 
@@ -192,7 +192,7 @@ For `Windows 10 IoT Core`, you can publish the application by running the `publi
 .\publish -example win32 -runtime win-arm
 ```
 
-Make sure to also copy the `corerundll32.dll` and the `corehook32.dll` to the directory of the program. For example, the application directory structure should look like this:
+Make sure to also copy the `coreload32.dll` and the `corehook32.dll` to the directory of the program. For example, the application directory structure should look like this:
 
 ```
 [+]Publish\win32\win-arm\
@@ -205,7 +205,7 @@ Make sure to also copy the `corerundll32.dll` and the `corehook32.dll` to the di
     [-] CoreHook.FileMonitor.dll
     [-] CoreHook.FileMonitor.exe
     [-] corehook32.dll
-    [-] corerundll32.dll
+    [-] coreload32.dll
     ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,21 @@ CoreHook supports application function call interception on various architecture
 
 ### Windows
 
-The native hosting module requires either a global `dotnet.runtimeconfig.json` file or a `CoreHook.CoreLoad.runtimeconfig.json` file (located next to `CoreHook.CoreLoad.dll` in the CoreHook output directory) to initialize CoreCLR. The `runtimeconfig` file must contain the framework information to be hosted in the target application.
+If you are building the CoreHook project (for example, with `dotnet build`) and not publishing it, you must setup the project configuration as described below.
 
-An example of the `runtimeconfig.json` configuration file is:
+#### Configuration
+
+The native hosting module requires either: 1) A global `dotnet.runtimeconfig.json` file or 2) a local `CoreHook.CoreLoad.runtimeconfig.json` file
+(located next to `CoreHook.CoreLoad.dll` in the CoreHook output directory) to initialize CoreCLR. The host module will first attempt to
+use the global configuration file if it exists, then it will check for a local configuration file, and finally it will use the directory of the `CoreHook.CoreLoad.dll` assembly for resolving dependencies.
+
+The `runtimeconfig` file must contain the framework information for hosting .NET Core in the target application.
+When you build any .NET Core application, these files are generated to the output directory. [For more information on the
+configuration options, see here](https://github.com/dotnet/cli/blob/master/Documentation/specs/runtime-configuration-file.md).
+
+You can use the `CoreHook.FileMonitor.runtimeconfig.json` and `CoreHook.FileMonitor.runtimeconfig.dev.json` files found in your build output directory as references for creating the global or local configuration files.
+
+An example of the contents of a `runtimeconfig.json` configuration file is:
 ```json
 {
   "runtimeOptions": {
@@ -97,25 +109,26 @@ An example of the `runtimeconfig.json` configuration file is:
 }
 ```
 
-You can also set additional probing paths for the host module to search for dependencies such as NuGet packages with a `CoreHook.CoreLoad.runtimeconfig.dev.json` file.
+You can also set additional probing paths for the host module to search for dependencies such as NuGet packages by creating a separate `CoreHook.CoreLoad.runtimeconfig.dev.json` file, which should look like:
 
 ```json
 {
   "runtimeOptions": {
     "additionalProbingPaths": [
-      "C:\\Users\\Thierry\\.dotnet\\store\\|arch|\\|tfm|",
-      "C:\\Users\\Thierry\\.nuget\\packages",
+      "C:\\Users\\<user>\\.dotnet\\store\\|arch|\\|tfm|",
+      "C:\\Users\\<user>\\.nuget\\packages",
       "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder"
     ]
   }
 }
 ```
 
-To use CoreHook, first create a `dotnet.runtimeconfig.json` file and save it to a folder. This will be the global configuration file that will be used by CoreHook to initialize the runtime in the target processs. In this example, our file is at `C:\CoreHook\dotnet.runtimeconfig.json`.
+#### Global Configuration
+To use CoreHook, first create a `dotnet.runtimeconfig.json` file and save it to a folder. This will be the global configuration file the project uses to initialize the runtime in the target processs. In this example, our file is saved at `C:\CoreHook\dotnet.runtimeconfig.json`.
 
 The runtime configuration file should look like the one below, where `additionalProbingPaths` contains file paths the host module can check for additional dependencies.
 
-**Notice: Either replace `user_name` with your local computer user name or modify the paths to point to where your NuGet packages are installed.**
+**Notice: Either replace `<user>` with your local computer user name or modify the paths to point to where your NuGet packages are installed. Take a look at `CoreHook.FileMonitor.runtimeconfig.dev.json` in the output directory to find your paths.**
 
 ```json
 {
@@ -126,15 +139,16 @@ The runtime configuration file should look like the one below, where `additional
       "version": "2.2.0"
     },
     "additionalProbingPaths": [
-      "C:\\Users\\user_name\\.dotnet\\store\\|arch|\\|tfm|",
-      "C:\\Users\\user_name\\.nuget\\packages",
+      "C:\\Users\\<user>\\.dotnet\\store\\|arch|\\|tfm|",
+      "C:\\Users\\<user>\\.nuget\\packages",
       "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder"
     ]
   }
 }
 ```
 
-Set the environment variables for the `x86` and `x64` applications to the directory of the runtime configuration file. This allows you to have different configuration files for the runtime for `32-bit` and `64-bit` applications.
+Set the environment variables for the `x86` and `x64` applications to the directory of the runtime configuration file. This allows you to have different configuration files for `32-bit` and `64-bit` applications. 
+This guide assumes you have installed the `2.2` runtime for both architectures.
 
 For example (if you saved the file another installation directory or drive, make sure to use that path):
 

--- a/download-deps.cmd
+++ b/download-deps.cmd
@@ -1,0 +1,2 @@
+@ECHO OFF
+PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0download-deps.ps1' %*; exit $LASTEXITCODE"

--- a/download-deps.ps1
+++ b/download-deps.ps1
@@ -1,0 +1,105 @@
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip
+{
+    param([string]$zipfile, [string]$outpath)
+
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
+
+Write-Host Downloading native binaries from GitHub Releases...
+
+$detourModulePath  = "deps/corehook"
+$hostingModulePath = "deps/coreload"
+
+$architecturewinx86   = "win-x86"
+$architecturewinx64   = "win-x64"
+$architecturewinarm   = "win-arm"
+$architecturewinarm64 = "win-arm64"
+
+if (Test-Path "$PSScriptRoot/$detourModulePath/")
+{
+    Remove-Item "$PSScriptRoot/$detourModulePath/" -Force -Recurse | Out-Null
+}
+
+if (Test-Path "$PSScriptRoot/$hostingModulePath/")
+{
+    Remove-Item "$PSScriptRoot/$hostingModulePath/" -Force -Recurse | Out-Null
+}
+
+$detourModulePathWinx86 = "$PSScriptRoot/$detourModulePath/$architecturewinx86"
+$detourModulePathWinx64 = "$PSScriptRoot/$detourModulePath/$architecturewinx64"
+$detourModulePathWinARM = "$PSScriptRoot/$detourModulePath/$architecturewinarm"
+$detourModulePathWinARM64 = "$PSScriptRoot/$detourModulePath/$architecturewinarm64"
+
+$hostingModulePathWinx86 = "$PSScriptRoot/$hostingModulePath/$architecturewinx86"
+$hostingModulePathWinx64 = "$PSScriptRoot/$hostingModulePath/$architecturewinx64"
+$hostingModulePathWinARM = "$PSScriptRoot/$hostingModulePath/$architecturewinarm"
+$hostingModulePathWinARM64 = "$PSScriptRoot/$hostingModulePath/$architecturewinarm64"
+
+New-Item -ItemType Directory -Force -Path "$detourModulePathWinx86" | Out-Null
+New-Item -ItemType Directory -Force -Path "$detourModulePathWinx64" | Out-Null
+New-Item -ItemType Directory -Force -Path "$detourModulePathWinARM" | Out-Null
+New-Item -ItemType Directory -Force -Path "$detourModulePathWinARM64" | Out-Null
+
+New-Item -ItemType Directory -Force -Path "$hostingModulePathWinx86" | Out-Null
+New-Item -ItemType Directory -Force -Path "$hostingModulePathWinx64" | Out-Null
+New-Item -ItemType Directory -Force -Path "$hostingModulePathWinARM" | Out-Null
+New-Item -ItemType Directory -Force -Path "$hostingModulePathWinARM64" | Out-Null
+
+function DownloadRelease
+{
+    param([string]$repository, [string]$releasefile, [string]$outDir)
+
+    $downloadUrl = "$repository/releases/download/$tag/$releasefile"
+
+    Write-Host "Download url: $downloadUrl"
+
+    $client = New-Object System.Net.WebClient
+    $client.DownloadFile(
+        $downloadUrl,
+        "$outDir/$releasefile")
+    if( -not $? )
+    {
+        $msg = $Error[0].Exception.Message
+        Write-Error "Couldn't download $releasefile. This most likely indicates the Windows native build failed."
+        exit
+    }
+
+    Unzip "$outDir/$releasefile" "$outDir"        
+}
+
+# Download the application function detour module
+$repo = "unknownv2/CoreHook.Hooking"
+$releases = "https://api.github.com/repos/$repo/releases"
+
+Write-Host "Determining latest release for $repo"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$tag = (Invoke-WebRequest -Uri $releases -UseBasicParsing | ConvertFrom-Json)[0].tag_name
+
+Write-Host "Dowloading latest release from $repo"
+
+$repository = "https://github.com/unknownv2/CoreHook.Hooking"
+
+DownloadRelease $repository "corehook-Release-x86.zip" $detourModulePathWinx86
+DownloadRelease $repository "corehook-Release-x64.zip" $detourModulePathWinx64
+DownloadRelease $repository "corehook-Release-ARM.zip" $detourModulePathWinARM
+DownloadRelease $repository "corehook-Release-ARM64.zip" $detourModulePathWinARM64
+
+
+# Download the CoreCLR hosting module
+$repo = "unknownv2/CoreHook.Host"
+$releases = "https://api.github.com/repos/$repo/releases"
+
+Write-Host "Determining latest release for $repo"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$tag = (Invoke-WebRequest -Uri $releases -UseBasicParsing | ConvertFrom-Json)[0].tag_name
+
+Write-Host "Dowloading latest release from $repo"
+
+$repository = "https://github.com/unknownv2/CoreHook.Host"
+
+DownloadRelease $repository "coreload-Release-x86.zip" $hostingModulePathWinx86
+DownloadRelease $repository "coreload-Release-x64.zip" $hostingModulePathWinx64
+DownloadRelease $repository "coreload-Release-ARM.zip" $hostingModulePathWinARM
+DownloadRelease $repository "coreload-Release-ARM64.zip" $hostingModulePathWinARM64

--- a/examples/Common/CoreHook.Examples.Common/CoreHook.Examples.Common.csproj
+++ b/examples/Common/CoreHook.Examples.Common/CoreHook.Examples.Common.csproj
@@ -8,10 +8,14 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>$(OutputDir)</OutputPath>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>$(OutputDir)</OutputPath>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +24,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\CoreHook.BinaryInjection\CoreHook.BinaryInjection.csproj" />
-    <ProjectReference Include="..\..\..\src\CoreHook.IPC\CoreHook.IPC.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/Common/CoreHook.Examples.Common/ModulesPathHelper.cs
+++ b/examples/Common/CoreHook.Examples.Common/ModulesPathHelper.cs
@@ -11,11 +11,11 @@ namespace CoreHook.Examples.Common
         /// <summary>
         /// The name of the .NET Core hosting module for 64-bit processes.
         /// </summary>
-        private const string CoreHostModule64 = "corerundll64.dll";
+        private const string CoreHostModule64 = "coreload64.dll";
         /// <summary>
         /// The name of the .NET Core hosting module for 32-bit processes.
         /// </summary>
-        private const string CoreHostModule32 = "corerundll32.dll";
+        private const string CoreHostModule32 = "coreload32.dll";
         /// <summary>
         /// The name of the native detour module for 64-bit processes.
         /// </summary>

--- a/examples/Common/CoreHook.Examples.Common/ModulesPathHelper.cs
+++ b/examples/Common/CoreHook.Examples.Common/ModulesPathHelper.cs
@@ -113,29 +113,29 @@ namespace CoreHook.Examples.Common
             bool is64BitProcess,
             out string coreRootPath)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var applicationBase = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                if (!string.IsNullOrWhiteSpace(applicationBase))
+                {
+                    // Check if we are using a published application or a local
+                    // runtime configuration file, in which case we don't need
+                    // the paths from the environment variables.
+                    if (IsPublishedApplication(applicationBase)
+                        || HasLocalRuntimeConfiguration(applicationBase))
+                    {
+                        // Set the directory for finding dependencies to the application base directory.
+                        coreRootPath = applicationBase;
+                        return true;
+                    }
+                }
+            }
+
             // Path to the directory containing the CoreCLR runtime configuration file.
             coreRootPath = GetCoreRootPath(is64BitProcess);
 
             if (string.IsNullOrWhiteSpace(coreRootPath))
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    var applicationBase = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                    if (!string.IsNullOrWhiteSpace(applicationBase))
-                    {
-                        // Check if we are using a published application or a local
-                        // runtime configuration file, in which case we don't need
-                        // the paths from the environment variables.
-                        if (IsPublishedApplication(applicationBase)
-                            || HasLocalRuntimeConfiguration(applicationBase))
-                        {
-                            // Set the directory for finding dependencies to the application base directory.
-                            coreRootPath = applicationBase;
-                            return true;
-                        }
-                    }
-                }
-
                 Console.WriteLine(is64BitProcess
                     ? "CoreCLR root path was not set for 64-bit processes."
                     : "CoreCLR root path was not set for 32-bit processes.");

--- a/publish.ps1
+++ b/publish.ps1
@@ -57,7 +57,6 @@ function exec([string]$_cmd) {
     }
 }
 
-exec dotnet publish $ExampleDir --configuration $Configuration -r $runtime -o $ExampleOutputDir '-warnaserror:CS1591'
-exec dotnet publish $ExampleHookDir --configuration $Configuration -r $runtime -o $ExampleHookOutputDir '-warnaserror:CS1591'
-
+exec dotnet publish $ExampleDir --configuration $Configuration -r $runtime -o $ExampleOutputDir
+exec dotnet publish $ExampleHookDir --configuration $Configuration -r $runtime -o $ExampleHookOutputDir
 

--- a/src/CoreHook.BinaryInjection/Loader/HostArguments.cs
+++ b/src/CoreHook.BinaryInjection/Loader/HostArguments.cs
@@ -6,6 +6,5 @@ namespace CoreHook.BinaryInjection.Loader
         public bool Verbose { get; set; }
         public string PayloadFileName { get; set; }
         public string CoreRootPath { get; set; }
-        public string CoreLibrariesPath { get; set; }
     }
 }

--- a/src/CoreHook.BinaryInjection/Loader/HostFunctionArguments.cs
+++ b/src/CoreHook.BinaryInjection/Loader/HostFunctionArguments.cs
@@ -26,7 +26,6 @@ namespace CoreHook.BinaryInjection.Loader
                 // Write the paths used for hosting the CLR.
                 writer.Write(PathArgumentsHelper.GetPathArray(LoaderArguments.PayloadFileName, LoaderConfig));
                 writer.Write(PathArgumentsHelper.GetPathArray(LoaderArguments.CoreRootPath, LoaderConfig));
-                writer.Write(PathArgumentsHelper.GetPathArray(LoaderArguments.CoreLibrariesPath ?? string.Empty, LoaderConfig));
 
                 return ms.ToArray();
             }

--- a/src/CoreHook.BinaryInjection/Loader/IHostArguments.cs
+++ b/src/CoreHook.BinaryInjection/Loader/IHostArguments.cs
@@ -11,6 +11,5 @@ namespace CoreHook.BinaryInjection.Loader
         bool Verbose { get; }
         string PayloadFileName { get; }
         string CoreRootPath { get; }
-        string CoreLibrariesPath { get; }
     }
 }

--- a/src/CoreHook.BinaryInjection/RemoteInjection/NativeModulesConfiguration.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/NativeModulesConfiguration.cs
@@ -14,14 +14,9 @@ namespace CoreHook.BinaryInjection.RemoteInjection
         /// </summary>
         public string DetourLibrary { get; set; }
         /// <summary>
-        /// Directory path which contains the main CoreCLR modules for hosting the runtime
-        /// such as CoreCLR and clrjit libraries.
+        /// Directory path which contains the folder with a `dotnet.runtimeconfig.json`
+        /// containing properties for initializing CoreCLR.
         /// </summary>
         public string ClrRootPath { get; set; }
-        /// <summary>
-        /// Directory path which contains the CoreCLR Assembly reference
-        /// runtime libraries such as System.Private.CoreLib.dll.
-        /// </summary>
-        public string ClrLibrariesPath { get; set; }
     }
 }

--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
@@ -23,7 +23,7 @@ namespace CoreHook.BinaryInjection.RemoteInjection
         private static readonly IAssemblyDelegate CoreHookLoaderDelegate =
                 new AssemblyDelegate(
                 assemblyName: "CoreHook.CoreLoad",
-                typeName: "Loader",
+                typeName: "PluginLoader",
                 methodName: "Load");
 
         /// <summary>

--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
@@ -217,7 +217,6 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                                                 Verbose = remoteInjectorConfig.VerboseLog,
                                                 PayloadFileName = remoteInjectorConfig.ClrBootstrapLibrary,
                                                 CoreRootPath = remoteInjectorConfig.ClrRootPath,
-                                                CoreLibrariesPath = remoteInjectorConfig.ClrLibrariesPath
                                             }),
                                         FunctionName = new FunctionName { Module = remoteInjectorConfig.HostLibrary, Function = GetClrStartFunctionName() },
                                     });

--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjectorConfiguration.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjectorConfiguration.cs
@@ -33,7 +33,6 @@ namespace CoreHook.BinaryInjection.RemoteInjection
 
         public void SetNativeConfig(NativeModulesConfiguration nativeConfig)
         {
-            ClrLibrariesPath = nativeConfig.ClrLibrariesPath;
             ClrRootPath = nativeConfig.ClrRootPath;
             HostLibrary = nativeConfig.HostLibrary;
             DetourLibrary = nativeConfig.DetourLibrary;

--- a/src/CoreHook.CoreLoad/PluginLoader.cs
+++ b/src/CoreHook.CoreLoad/PluginLoader.cs
@@ -7,7 +7,7 @@ using CoreHook.IPC.Messages;
 
 namespace CoreHook.CoreLoad
 {
-    public class Loader
+    public class PluginLoader
     {
         /// <summary>
         /// The interface implemented by each plugin that we initialize.

--- a/src/CoreHook.IPC/Directory.Build.props
+++ b/src/CoreHook.IPC/Directory.Build.props
@@ -1,0 +1,28 @@
+<Project>
+
+<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup Condition="'$(Configuration)' != ''">
+    <DocumentationFile>$(BinDir)$(Configuration)/$(DefaultTargetFramework)/$(Platform)/$(MSBuildProjectName).xml</DocumentationFile>
+    <Authors>Thierry Bizimungu</Authors>
+    <Product>CoreHook</Product>
+    <Version>1.0.1</Version>
+    <PackageProjectUrl>https://github.com/unknownv2/CoreHook</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/unknownv2/CoreHook.git</RepositoryUrl>
+    <PackageLicenseUrl>https://github.com/unknownv2/CoreHook/blob/master/LICENSE</PackageLicenseUrl>
+    <Copyright>Copyright (c) 2018 Thierry Bizimungu</Copyright>  
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <RepositoryType>git</RepositoryType>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+    <IsPackable>true</IsPackable>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+    <Description>Library for facilitating interprocess communication (IPC).</Description>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+</Project>

--- a/tests/CoreHook.Tests/CoreLoadTest.cs
+++ b/tests/CoreHook.Tests/CoreLoadTest.cs
@@ -8,7 +8,7 @@ namespace CoreHook.Tests
         [Fact]
         public void ShouldThrowArgumentOutOfRange_For_Loader_IntPtrZeroParameter()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => CoreLoad.Loader.Load(IntPtr.Zero));
+            Assert.Throws<ArgumentOutOfRangeException>(() => CoreLoad.PluginLoader.Load(IntPtr.Zero));
         }
     }
 }


### PR DESCRIPTION
Modify project to use the new coreload module at https://github.com/unknownv2/CoreHook.Host.

This module now uses runtime configuration files instead of just the application base as was the case with the corerundll project.

The readme now contains a guideline on using the new module for initializing CoreCLR in the target application.

* Add a script for downloading the latest binaries for the native modules.
* Fix project configuration and publishing script to remove errors.