### PR TITLE
Update Windows PE header parsing

### DIFF
--- a/src/CoreHook.IPC/CoreHook.IPC.csproj
+++ b/src/CoreHook.IPC/CoreHook.IPC.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Platforms>AnyCPU</Platforms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/CoreHook.Memory/Formats/PortableExecutable/DataDirectory.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/DataDirectory.cs
@@ -4,8 +4,8 @@ namespace CoreHook.Memory.Formats.PortableExecutable
 {
     internal struct DataDirectory
     {
-        internal uint VirtualAddress;
-        internal uint Size;
+        internal uint VirtualAddress { get; }
+        internal uint Size { get; }
 
         internal DataDirectory(BinaryReader reader, int offset)
         {

--- a/src/CoreHook.Memory/Formats/PortableExecutable/DataDirectory.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/DataDirectory.cs
@@ -1,0 +1,17 @@
+﻿using System.IO;
+
+namespace CoreHook.Memory.Formats.PortableExecutable
+{
+    internal struct DataDirectory
+    {
+        internal uint VirtualAddress;
+        internal uint Size;
+
+        internal DataDirectory(BinaryReader reader, int offset)
+        {
+            reader.BaseStream.Position = offset;
+            VirtualAddress = reader.ReadUInt32();
+            Size = reader.ReadUInt32();
+        }
+    }
+}

--- a/src/CoreHook.Memory/Formats/PortableExecutable/DosHeader.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/DosHeader.cs
@@ -1,0 +1,63 @@
+﻿using System.IO;
+
+namespace CoreHook.Memory.Formats.PortableExecutable
+{
+    internal class DosHeader
+    {
+        public ushort e_magic;
+        public ushort e_cblp;
+        public ushort e_cp;
+        public ushort e_crlc;
+        public ushort e_cparhdr;
+        public ushort e_minalloc;
+        public ushort e_maxalloc;
+        public ushort e_ss;
+        public ushort e_sp;
+        public ushort e_csum;
+        public ushort e_ip;
+        public ushort e_cs;
+        public ushort e_lfarlc;
+        public ushort e_ovno;
+        public ushort[] e_res1;
+        public ushort e_oemid;
+        public ushort e_oeminfo;
+        public ushort[] e_res2;
+        public uint e_lfanew;
+
+        const int res1_count = 4;
+        const int res2_count = 10;
+
+        internal DosHeader(BinaryReader reader)
+        {
+            e_magic = reader.ReadUInt16();
+            e_cblp = reader.ReadUInt16();
+            e_cp = reader.ReadUInt16();
+            e_crlc = reader.ReadUInt16();
+            e_cparhdr = reader.ReadUInt16();
+            e_minalloc = reader.ReadUInt16();
+            e_maxalloc = reader.ReadUInt16();
+            e_ss = reader.ReadUInt16();
+            e_sp = reader.ReadUInt16();
+            e_csum = reader.ReadUInt16();
+            e_ip = reader.ReadUInt16();
+            e_cs = reader.ReadUInt16();
+            e_lfarlc = reader.ReadUInt16();
+            e_ovno = reader.ReadUInt16();
+            e_res1 = new ushort[res1_count];
+            for (int i = 0; i < res1_count; i++)
+            {
+                e_res1[i] = reader.ReadUInt16();
+            }
+
+            e_oemid = reader.ReadUInt16();
+            e_oeminfo = reader.ReadUInt16();
+            e_res2 = new ushort[res2_count];
+            for (int i = 0; i < res2_count; i++)
+            {
+                e_res2[i] = reader.ReadUInt16();
+            }
+
+            e_lfanew = reader.ReadUInt16();
+        }
+    }
+}

--- a/src/CoreHook.Memory/Formats/PortableExecutable/ExportDirectory.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/ExportDirectory.cs
@@ -1,0 +1,34 @@
+﻿using System.IO;
+
+namespace CoreHook.Memory.Formats.PortableExecutable
+{
+    internal class ExportDirectory
+    {
+        internal uint Characteristics { get; }
+        internal uint TimeDateStamp { get; }
+        internal ushort MajorVersion { get; }
+        internal ushort MinorVersion { get; }
+        internal uint Name { get; }
+        internal uint Base { get; }
+        internal uint NumberOfFunctions { get; }
+        internal uint NumberOfNames { get; }
+        internal uint AddressOfFunctions { get; }
+        internal uint AddressOfNames { get; }
+        internal uint AddressOfNameOrdinals { get; }
+
+        internal ExportDirectory(BinaryReader reader)
+        {
+            Characteristics = reader.ReadUInt32();
+            TimeDateStamp = reader.ReadUInt32();
+            MajorVersion = reader.ReadUInt16();
+            MinorVersion = reader.ReadUInt16();
+            Name = reader.ReadUInt32();
+            Base = reader.ReadUInt32();
+            NumberOfFunctions = reader.ReadUInt32();
+            NumberOfNames = reader.ReadUInt32();
+            AddressOfFunctions = reader.ReadUInt32();
+            AddressOfNames = reader.ReadUInt32();
+            AddressOfNameOrdinals = reader.ReadUInt32();
+        }
+    }
+}

--- a/src/CoreHook.Memory/Formats/PortableExecutable/FileHeader.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/FileHeader.cs
@@ -4,13 +4,13 @@ namespace CoreHook.Memory.Formats.PortableExecutable
 {
     internal class FileHeader
     {
-        internal FileHeaderMachine Machine;
-        internal ushort NumberOfSections;
-        internal uint TimeDateStamp;
-        internal uint PointerToSymbolTable;
-        internal uint NumberOfSymbols;
-        internal ushort SizeOfOptionalHeader;
-        internal ushort Characteristics;
+        internal FileHeaderMachine Machine { get; }
+        internal ushort NumberOfSections { get; }
+        internal uint TimeDateStamp { get; }
+        internal uint PointerToSymbolTable { get; }
+        internal uint NumberOfSymbols { get; }
+        internal ushort SizeOfOptionalHeader { get; }
+        internal ushort Characteristics { get; }
 
         internal FileHeader(BinaryReader reader)
         {

--- a/src/CoreHook.Memory/Formats/PortableExecutable/FileHeader.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/FileHeader.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+
+namespace CoreHook.Memory.Formats.PortableExecutable
+{
+    internal class FileHeader
+    {
+        internal FileHeaderMachine Machine;
+        internal ushort NumberOfSections;
+        internal uint TimeDateStamp;
+        internal uint PointerToSymbolTable;
+        internal uint NumberOfSymbols;
+        internal ushort SizeOfOptionalHeader;
+        internal ushort Characteristics;
+
+        internal FileHeader(BinaryReader reader)
+        {
+            Machine = (FileHeaderMachine)reader.ReadUInt16();
+            NumberOfSections = reader.ReadUInt16();
+            TimeDateStamp = reader.ReadUInt32();
+            PointerToSymbolTable = reader.ReadUInt32();
+            NumberOfSymbols = reader.ReadUInt32();
+            SizeOfOptionalHeader = reader.ReadUInt16();
+            Characteristics = reader.ReadUInt16();
+        }
+
+        internal bool Is64Bit => Machine == FileHeaderMachine.AMD64 || Machine == FileHeaderMachine.ARM64;
+    }
+}

--- a/src/CoreHook.Memory/Formats/PortableExecutable/FileHeaderMachine.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/FileHeaderMachine.cs
@@ -1,0 +1,11 @@
+﻿
+namespace CoreHook.Memory.Formats.PortableExecutable
+{
+    internal enum FileHeaderMachine
+    {
+        I386 = 0x14c,   // Intel 386 (32-bit)
+        ARMNT = 0x1c4,  // ARM Thumb-2 Little-Endian (32-bit)
+        AMD64 = 0x8664, // AMD64 (64-bit)
+        ARM64 = 0xaa64  // ARM64 Little-Endian (64-bit)
+    }
+}

--- a/src/CoreHook.Memory/Formats/PortableExecutable/ImageDirectoryEntry.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/ImageDirectoryEntry.cs
@@ -1,0 +1,22 @@
+﻿
+namespace CoreHook.Memory.Formats.PortableExecutable
+{
+    internal enum ImageDirectoryEntry
+    {
+        ImageDirectoryEntryExport = 0,
+        ImageDirectoryEntryImport,
+        ImageDirectoryEntryResource,
+        ImageDirectoryEntryException,
+        ImageDirectoryEntrySecurity,
+        ImageDirectoryEntryBaseReloc,
+        ImageDirectoryEntryDebug,
+        ImageDirectoryEntryArchitecture,
+        ImageDirectoryEntryGlobalPtr,
+        ImageDirectoryEntryTls,
+        ImageDirectoryEntryLoadConfig,
+        ImageDirectoryEntryBoundImport,
+        ImageDirectoryEntryIat,
+        ImageDirectoryEntryDelayImport,
+        ImageDirectoryEntryCOMDescriptor
+    }
+}

--- a/src/CoreHook.Memory/Formats/PortableExecutable/NtHeaders.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/NtHeaders.cs
@@ -1,0 +1,18 @@
+﻿using System.IO;
+
+namespace CoreHook.Memory.Formats.PortableExecutable
+{
+    internal class NtHeaders
+    {
+        internal uint Signature;
+        internal FileHeader FileHeader;
+        internal OptionalHeader OptionalHeader;
+
+        internal NtHeaders(BinaryReader reader)
+        {
+            Signature = reader.ReadUInt32();
+            FileHeader = new FileHeader(reader);
+            OptionalHeader = new OptionalHeader(reader, FileHeader.Is64Bit);
+        }
+    }
+}

--- a/src/CoreHook.Memory/Formats/PortableExecutable/NtHeaders.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/NtHeaders.cs
@@ -4,9 +4,9 @@ namespace CoreHook.Memory.Formats.PortableExecutable
 {
     internal class NtHeaders
     {
-        internal uint Signature;
-        internal FileHeader FileHeader;
-        internal OptionalHeader OptionalHeader;
+        internal uint Signature { get; }
+        internal FileHeader FileHeader { get; }
+        internal OptionalHeader OptionalHeader { get; }
 
         internal NtHeaders(BinaryReader reader)
         {

--- a/src/CoreHook.Memory/Formats/PortableExecutable/OptionalHeader.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/OptionalHeader.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+
+namespace CoreHook.Memory.Formats.PortableExecutable
+{
+    internal class OptionalHeader
+    {
+        internal readonly DataDirectory[] DataDirectory;
+        private const int DirectoryEntryCount = 16;
+
+        internal OptionalHeader(BinaryReader reader, bool is64Bit)
+        {
+            int offset = (int)reader.BaseStream.Position;
+
+            DataDirectory = new DataDirectory[DirectoryEntryCount];
+            for (int i = 0; i < DirectoryEntryCount; i++)
+            {
+                if (!is64Bit)
+                {
+                    DataDirectory[i] = new DataDirectory(reader, offset + 0x60 + i * 0x08);
+                }
+                else
+                {
+                    DataDirectory[i] = new DataDirectory(reader, offset + 0x70 + i * 0x08);
+                }
+            }
+        }
+
+        internal DataDirectory GetDataDirectory(ImageDirectoryEntry entry) => DataDirectory[(int) entry];
+    }
+}

--- a/src/CoreHook.Memory/ThreadHelper.Windows.cs
+++ b/src/CoreHook.Memory/ThreadHelper.Windows.cs
@@ -44,25 +44,17 @@ namespace CoreHook.Memory
             DataDirectory exportDirectory = 
                 GetExportDataDirectory(ReadPage(processHandle, moduleInfo.BaseOfDll), ImageDirectoryEntry.ImageDirectoryEntryExport);
 
-            var exportTable = new byte[exportDirectory.Size];
+            // Read and parse the export directory from the module.
             var exportTableAddress = moduleInfo.BaseOfDll + (int)exportDirectory.VirtualAddress;
-            if (!Interop.Kernel32.ReadProcessMemory(
-                processHandle,
-                exportTableAddress,
-                exportTable,
-                new UIntPtr((uint)exportTable.Length),
-                out UIntPtr bytesRead) || bytesRead.ToUInt32() != exportTable.Length)
-            {
-                throw new Win32Exception($"Cannot read export table at {exportTableAddress.ToInt64()}");
-            }
+            var exportTable = ReadPage(processHandle, exportTableAddress, (int)exportDirectory.Size);
 
             return new IntPtr(moduleInfo.BaseOfDll.ToInt64() +
-                GetAddressFromExportTable(exportTable, exportDirectory.VirtualAddress, functionName).ToInt64());
+                GetFunctionAddressFromExportDirectory(exportTable, exportDirectory.VirtualAddress, functionName).ToInt64());
         }
 
-        private static byte[] ReadPage(SafeProcessHandle processHandle, IntPtr pageAddress)
+        private static byte[] ReadPage(SafeProcessHandle processHandle, IntPtr pageAddress, int? pageSize = null)
         {
-            var page = new byte[Environment.SystemPageSize];
+            var page = new byte[pageSize ?? Environment.SystemPageSize];
             if(!Interop.Kernel32.ReadProcessMemory(
                 processHandle,
                 pageAddress,
@@ -71,7 +63,7 @@ namespace CoreHook.Memory
                 out UIntPtr bytesRead) || bytesRead.ToUInt32() != page.Length)
             {
                 throw new Win32Exception(
-                    $"Failed to read process memory page: {pageAddress.ToInt64():X16}.");
+                    $"Failed to read process memory at {pageAddress.ToInt64():X16}.");
             }
             return page;
         }
@@ -124,7 +116,7 @@ namespace CoreHook.Memory
             int moduleCount = 0;
             for (; ;)
             {
-                bool enumResult = false;
+                bool enumResult;
                 try
                 {
                     moduleHandlesArrayHandle = GCHandle.Alloc(moduleHandles, GCHandleType.Pinned);
@@ -165,50 +157,42 @@ namespace CoreHook.Memory
             }
         }
 
-        private static IntPtr GetAddressFromExportTable(byte[] exportTable, uint exportTableRva, string functionName)
+        private static IntPtr GetFunctionAddressFromExportDirectory(byte[] exportDirectoryBuffer, uint exportTableRva, string functionName)
         {
-            using (var reader = new BinaryReader(new MemoryStream(exportTable)))
+            uint RvaToDirectoryPosition(uint address) => address - exportTableRva;
+
+            using (var reader = new BinaryReader(new MemoryStream(exportDirectoryBuffer)))
             {
-                reader.BaseStream.Position = 0x10;
-
-                // Read Ordinal Base
-                reader.ReadInt32();
-
-                var addressTableEntryCount = reader.ReadUInt32();
-                var namePointerTableEntryCount = reader.ReadUInt32();
-                var exportAddressTableRva = reader.ReadUInt32() - exportTableRva;
-                var exportNamePointerTableRva = reader.ReadUInt32() - exportTableRva;
-                var ordinalTableRva = reader.ReadUInt32() - exportTableRva;
-
-                reader.BaseStream.Position = exportNamePointerTableRva;
+                var exportDirectory = new ExportDirectory(reader);
 
                 var functionAddress = IntPtr.Zero;
+                var exportFunctionOffset = RvaToDirectoryPosition(exportDirectory.AddressOfFunctions);
+                var ordinalOffset = RvaToDirectoryPosition(exportDirectory.AddressOfNameOrdinals);
+                var exportNameOffset = RvaToDirectoryPosition(exportDirectory.AddressOfNames);
 
-                for(var x = 0; x < namePointerTableEntryCount; ++x)
+                reader.BaseStream.Position = exportNameOffset;
+                for(var i = 0; i < exportDirectory.NumberOfNames; ++i)
                 {
-                    reader.BaseStream.Position = exportNamePointerTableRva + (x * 4);
+                    reader.BaseStream.Position = exportNameOffset + (i * sizeof(uint));
 
-                    var nameRva = reader.ReadUInt32();
-
-                    if(nameRva == 0)
+                    var nameOffset = reader.ReadUInt32();
+                    if(nameOffset == 0)
                     {
                         continue;
                     }
 
-                    reader.BaseStream.Position = nameRva - exportTableRva;
-
+                    reader.BaseStream.Position = RvaToDirectoryPosition(nameOffset);
                     if(functionName == ReadAsciiString(reader))
                     {
-                        reader.BaseStream.Position = ordinalTableRva + (x * 2);
-                        var ordinal = reader.ReadUInt16();
-
-                        if(ordinal >= addressTableEntryCount)
+                        reader.BaseStream.Position = ordinalOffset + (i * sizeof(ushort));
+                        var ordinalIndex = reader.ReadUInt16();
+                        if(ordinalIndex >= exportDirectory.NumberOfFunctions)
                         {
-                            throw new Win32Exception("Invalid function export table");
+                            throw new Win32Exception(
+                                $"Function ordinal out of range {ordinalIndex} >= {exportDirectory.NumberOfFunctions}");
                         }
 
-                        reader.BaseStream.Position = exportAddressTableRva + (ordinal * 4);
-
+                        reader.BaseStream.Position = exportFunctionOffset + (ordinalIndex * sizeof(uint));
                         functionAddress = new IntPtr(reader.ReadUInt32());
                     }
                 }

--- a/src/CoreHook/CoreHook.csproj
+++ b/src/CoreHook/CoreHook.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Platforms>AnyCPU</Platforms>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>  
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>  
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Implement new PE header parsing code used to read the export directory entries to get a function's address using it's name for a remote process.

This method uses structures so the parsing code is clearer instead of seeking to random offsets and reading data, skipping around with a stream.

This will hopefully improve code readability.