### PR TITLE
Fix: Retry EnumProcessModulesEx to avoid failures

### DIFF
--- a/src/CoreHook.Memory/ThreadHelper.Windows.cs
+++ b/src/CoreHook.Memory/ThreadHelper.Windows.cs
@@ -112,7 +112,7 @@ namespace CoreHook.Memory
 
         private static IntPtr[] GetProcessModuleHandles(SafeProcessHandle processHandle)
         {
-            IntPtr[] moduleHandles = new IntPtr[64];
+            IntPtr[] moduleHandles = new IntPtr[1024];
             GCHandle moduleHandlesArrayHandle = new GCHandle();
             int moduleCount = 0;
             for (; ;)

--- a/src/CoreHook.Memory/ThreadHelper.Windows.cs
+++ b/src/CoreHook.Memory/ThreadHelper.Windows.cs
@@ -123,7 +123,7 @@ namespace CoreHook.Memory
                     moduleHandlesArrayHandle = GCHandle.Alloc(moduleHandles, GCHandleType.Pinned);
                     // Attempt an arbitrary amount of times since EnumProcessModulesEx can fail
                     // as a result of regular OS operations.
-                    for (int i = 0; i < 50; i++)
+                    for (int i = 0; i < 100; i++)
                     {
                         enumResult = Interop.Psapi.EnumProcessModulesEx(processHandle,
                             moduleHandlesArrayHandle.AddrOfPinnedObject(),
@@ -149,7 +149,9 @@ namespace CoreHook.Memory
 
                 moduleCount /= IntPtr.Size;
                 if (moduleCount <= moduleHandles.Length)
+                {
                     break;
+                }
 
                 moduleHandles = new IntPtr[moduleHandles.Length * 2];
             }


### PR DESCRIPTION
EnumProcessModulesEx can fail for reasons known as an operating system issue, so we increase the number of attempts we try so failures don't stop the injection process.

See here for more information:

https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs#L101

>   Also, EnumProcessModules is not a reliable method to get the modules for a process. 
 If OS loader is touching module information, this method might fail and copy part of the data.
 This is no easy solution to this problem. The only reliable way to fix this is to
 suspend all the threads in target process. Of course we don't want to do this in Process class.
 So we just to try avoid the race by calling the same method 50 (an arbitrary number) times.