### PR TITLE
Update Portable Executable structure classes

### DIFF
--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
@@ -8,7 +8,6 @@ using CoreHook.BinaryInjection.Loader;
 using CoreHook.BinaryInjection.ProcessUtils;
 using CoreHook.CoreLoad.Data;
 using CoreHook.IPC.Platform;
-using CoreHook.Memory;
 using CoreHook.Memory.Processes;
 using static CoreHook.BinaryInjection.ProcessUtils.ProcessHelper;
 
@@ -172,7 +171,7 @@ namespace CoreHook.BinaryInjection.RemoteInjection
             }
 
             InjectionHelper.BeginInjection(targetProcessId);
-            
+
             using (InjectionHelper.CreateServer(remoteInjectorConfig.InjectionPipeName, pipePlatform))
             {
                 try

--- a/src/CoreHook.Memory/Formats/PortableExecutable/DosHeader.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/DosHeader.cs
@@ -4,28 +4,28 @@ namespace CoreHook.Memory.Formats.PortableExecutable
 {
     internal class DosHeader
     {
-        public ushort e_magic;
-        public ushort e_cblp;
-        public ushort e_cp;
-        public ushort e_crlc;
-        public ushort e_cparhdr;
-        public ushort e_minalloc;
-        public ushort e_maxalloc;
-        public ushort e_ss;
-        public ushort e_sp;
-        public ushort e_csum;
-        public ushort e_ip;
-        public ushort e_cs;
-        public ushort e_lfarlc;
-        public ushort e_ovno;
-        public ushort[] e_res1;
-        public ushort e_oemid;
-        public ushort e_oeminfo;
-        public ushort[] e_res2;
-        public uint e_lfanew;
+        internal ushort e_magic{ get; }
+        internal ushort e_cblp{ get; }
+        internal ushort e_cp{ get; }
+        internal ushort e_crlc{ get; }
+        internal ushort e_cparhdr{ get; }
+        internal ushort e_minalloc{ get; }
+        internal ushort e_maxalloc{ get; }
+        internal ushort e_ss{ get; }
+        internal ushort e_sp{ get; }
+        internal ushort e_csum{ get; }
+        internal ushort e_ip{ get; }
+        internal ushort e_cs{ get; }
+        internal ushort e_lfarlc{ get; }
+        internal ushort e_ovno{ get; }
+        internal ushort[] e_res1{ get; }
+        internal ushort e_oemid{ get; }
+        internal ushort e_oeminfo{ get; }
+        internal ushort[] e_res2{ get; }
+        internal uint e_lfanew{ get; }
 
-        const int res1_count = 4;
-        const int res2_count = 10;
+        private const int res1_count = 4;
+        private const int res2_count = 10;
 
         internal DosHeader(BinaryReader reader)
         {

--- a/src/CoreHook.Memory/Formats/PortableExecutable/OptionalHeader.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/OptionalHeader.cs
@@ -4,7 +4,7 @@ namespace CoreHook.Memory.Formats.PortableExecutable
 {
     internal class OptionalHeader
     {
-        internal readonly DataDirectory[] DataDirectory;
+        internal DataDirectory[] DataDirectory { get; }
         private const int DirectoryEntryCount = 16;
 
         internal OptionalHeader(BinaryReader reader, bool is64Bit)


### PR DESCRIPTION
Make class variables accessible as properties and mark them internal instead of public since they shouldn't be used outside of the project.