### PR TITLE
refactor: Add separate interfaces for thread creation and module load…

### DIFF
--- a/src/CoreHook.BinaryInjection/Loader/ModuleInjector.cs
+++ b/src/CoreHook.BinaryInjection/Loader/ModuleInjector.cs
@@ -4,17 +4,17 @@ namespace CoreHook.BinaryInjection.Loader
 {
     internal class ModuleInjector : IModuleInjector
     {
-        private readonly IProcessManager _processManager;
+        private readonly IModuleManager _moduleManager;
 
-        internal ModuleInjector(IProcessManager processManager)
+        internal ModuleInjector(IModuleManager moduleManager)
         {
-            _processManager = processManager;
+            _moduleManager = moduleManager;
         }
 
         /// <summary>
         /// Load a module into the process controlled by the process manager.
         /// </summary>
         /// <param name="path">File path of the module to be loaded.</param>
-        public void Inject(string path) => _processManager.InjectBinary(path);
+        public void Inject(string path) => _moduleManager.LoadModule(path);
     }
 }

--- a/src/CoreHook.BinaryInjection/Loader/RemoteThreadCreator.cs
+++ b/src/CoreHook.BinaryInjection/Loader/RemoteThreadCreator.cs
@@ -4,11 +4,11 @@ namespace CoreHook.BinaryInjection.Loader
 {
     internal class RemoteThreadCreator : IRemoteThreadCreator
     {
-        private readonly IProcessManager _processManager;
+        private readonly IThreadManager _threadManager;
 
-        internal RemoteThreadCreator(IProcessManager processManager)
+        internal RemoteThreadCreator(IThreadManager threadManager)
         {
-            _processManager = processManager;
+            _threadManager = threadManager;
         }
 
         public void ExecuteRemoteFunction(IRemoteFunctionCall call, bool waitForThreadExit)
@@ -18,7 +18,7 @@ namespace CoreHook.BinaryInjection.Loader
 
         private void ExecuteAssemblyWithArguments(IFunctionName moduleFunction, byte[] arguments, bool waitForThreadExit)
         {
-            _processManager.Execute(moduleFunction.Module, moduleFunction.Function, arguments, waitForThreadExit);
+            _threadManager.CreateThread(moduleFunction.Module, moduleFunction.Function, arguments, waitForThreadExit);
         }
     }
 }

--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
@@ -210,7 +210,8 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                                 assemblyLoader.CreateThread(
                                     new RemoteFunctionCall
                                     {
-                                        Arguments = new HostFunctionArguments(pathConfig,
+                                        Arguments = new HostFunctionArguments(
+                                            pathConfig,
                                             new HostArguments
                                             {
                                                 Verbose = remoteInjectorConfig.VerboseLog,
@@ -221,18 +222,19 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                                     });
 
                                 // Execute a .NET function in the remote process now that CoreCLR is started.
-                                assemblyLoader.CreateThread(new RemoteFunctionCall
-                                {
-                                    Arguments = new AssemblyFunctionArguments(
-                                        pathConfig,
-                                        CoreHookLoaderDelegate,
-                                        new PluginConfigurationArguments(
-                                            process.Is64Bit(),
-                                            assemblyLoader.CopyMemory(pluginArgumentsStream.GetBuffer(), pluginArgumentsLength),
-                                            pluginArgumentsLength)
-                                        ),
-                                    FunctionName = new FunctionName { Module = remoteInjectorConfig.HostLibrary, Function = GetClrExecuteManagedFunctionName() }
-                                }, false);
+                                assemblyLoader.CreateThread(
+                                    new RemoteFunctionCall
+                                    {
+                                        Arguments = new AssemblyFunctionArguments(
+                                            pathConfig,
+                                            CoreHookLoaderDelegate,
+                                            new PluginConfigurationArguments(
+                                                process.Is64Bit(),
+                                                assemblyLoader.CopyMemory(pluginArgumentsStream.GetBuffer(), pluginArgumentsLength),
+                                                pluginArgumentsLength)
+                                            ),
+                                        FunctionName = new FunctionName { Module = remoteInjectorConfig.HostLibrary, Function = GetClrExecuteManagedFunctionName() }
+                                    }, false);
 
                                 InjectionHelper.WaitForInjection(targetProcessId);
                             }

--- a/src/CoreHook.Memory/Processes/IModuleManager.cs
+++ b/src/CoreHook.Memory/Processes/IModuleManager.cs
@@ -1,0 +1,8 @@
+﻿
+namespace CoreHook.Memory.Processes
+{
+    public interface IModuleManager
+    {
+        void LoadModule(string modulePath);
+    }
+}

--- a/src/CoreHook.Memory/Processes/IProcessManager.cs
+++ b/src/CoreHook.Memory/Processes/IProcessManager.cs
@@ -2,10 +2,8 @@
 
 namespace CoreHook.Memory.Processes
 {
-    public interface IProcessManager : IDisposable
+    public interface IProcessManager : IModuleManager, IThreadManager, IDisposable
     {
-        void InjectBinary(string modulePath);
-        IntPtr Execute(string module, string function, byte[] arguments, bool waitForThreadExit = true);
         IntPtr CopyToProcess(byte[] data, int? size = null);
     }
 }

--- a/src/CoreHook.Memory/Processes/IThreadManager.cs
+++ b/src/CoreHook.Memory/Processes/IThreadManager.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace CoreHook.Memory.Processes
+{
+    public interface IThreadManager
+    {
+        IntPtr CreateThread(string module, string function, byte[] arguments, bool waitForThreadExit = true);
+    }
+}

--- a/src/CoreHook.Memory/Processes/ProcessManager.Windows.cs
+++ b/src/CoreHook.Memory/Processes/ProcessManager.Windows.cs
@@ -6,7 +6,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace CoreHook.Memory.Processes
 {
-    public sealed partial class ProcessManager : IProcessManager
+    public sealed class ProcessManager : IProcessManager
     {
         private readonly IMemoryManager _memoryManager;
         private readonly IProcess _process;
@@ -17,25 +17,26 @@ namespace CoreHook.Memory.Processes
             _memoryManager = new MemoryManager(process);
         }
 
-        public void InjectBinary(string modulePath)
+        public void LoadModule(string modulePath)
         {
-            ExecuteFunction(Path.Combine(
-                             Environment.ExpandEnvironmentVariables("%Windir%"),
-                             "System32",
-                             "kernel32.dll"),
-                             "LoadLibraryW",
-                             Encoding.Unicode.GetBytes(modulePath + "\0"));
+            ExecuteFunction(
+                Path.Combine(
+                    Environment.ExpandEnvironmentVariables("%Windir%"),
+                    "System32",
+                    "kernel32.dll"),
+                "LoadLibraryW",
+                Encoding.Unicode.GetBytes(modulePath + "\0"));
         }
 
         /// <summary>
-        /// Execute function inside the specified module with custom arguments.
+        /// Create a thread to execute a function within a module.
         /// </summary>
         /// <param name="module">The name of the module containing the desired function.</param>
         /// <param name="function">The name of the exported function we will call.</param>
         /// <param name="arguments">Serialized arguments for passing to the module function.</param>
         /// <param name="waitForThreadExit">We can wait for the thread to exit and then deallocate any memory
         /// we allocated or return immediately and deallocate the memory in a separate call.</param>
-        public IntPtr Execute(string module, string function, byte[] arguments, bool waitForThreadExit = true)
+        public IntPtr CreateThread(string module, string function, byte[] arguments, bool waitForThreadExit = true)
         {
             return ExecuteFunction(module, function, arguments, waitForThreadExit);
         }


### PR DESCRIPTION
…ing for the Process Manager

Since we don't need all methods of the process manager for the classes used to implement the .NET assembly loader, we can reduce the class dependencies.