### PR TITLE
Update how to determine the PE image type

### DIFF
--- a/src/CoreHook.Memory/Formats/PortableExecutable/FileHeader.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/FileHeader.cs
@@ -22,7 +22,5 @@ namespace CoreHook.Memory.Formats.PortableExecutable
             SizeOfOptionalHeader = reader.ReadUInt16();
             Characteristics = reader.ReadUInt16();
         }
-
-        internal bool Is64Bit => Machine == FileHeaderMachine.AMD64 || Machine == FileHeaderMachine.ARM64;
     }
 }

--- a/src/CoreHook.Memory/Formats/PortableExecutable/ImageMagic.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/ImageMagic.cs
@@ -1,0 +1,9 @@
+﻿
+namespace CoreHook.Memory.Formats.PortableExecutable
+{
+    internal enum ImageMagic : ushort
+    {
+        Magic32 = 0x10b,
+        Magic64 = 0x20b
+    }
+}

--- a/src/CoreHook.Memory/Formats/PortableExecutable/NtHeaders.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/NtHeaders.cs
@@ -12,7 +12,7 @@ namespace CoreHook.Memory.Formats.PortableExecutable
         {
             Signature = reader.ReadUInt32();
             FileHeader = new FileHeader(reader);
-            OptionalHeader = new OptionalHeader(reader, FileHeader.Is64Bit);
+            OptionalHeader = new OptionalHeader(reader);
         }
     }
 }

--- a/src/CoreHook.Memory/Formats/PortableExecutable/OptionalHeader.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/OptionalHeader.cs
@@ -5,16 +5,21 @@ namespace CoreHook.Memory.Formats.PortableExecutable
     internal class OptionalHeader
     {
         internal DataDirectory[] DataDirectory { get; }
+        internal ImageMagic ImageMagic { get; }
+
         private const int DirectoryEntryCount = 16;
 
-        internal OptionalHeader(BinaryReader reader, bool is64Bit)
+        internal OptionalHeader(BinaryReader reader)
         {
             int offset = (int)reader.BaseStream.Position;
+
+            // Read the image type (either PE32 or PE32+)
+            ImageMagic = (ImageMagic)reader.ReadUInt16();
 
             DataDirectory = new DataDirectory[DirectoryEntryCount];
             for (int i = 0; i < DirectoryEntryCount; i++)
             {
-                if (!is64Bit)
+                if (ImageMagic == ImageMagic.Magic32)
                 {
                     DataDirectory[i] = new DataDirectory(reader, offset + 0x60 + i * 0x08);
                 }

--- a/src/CoreHook/LocalHook.cs
+++ b/src/CoreHook/LocalHook.cs
@@ -272,5 +272,4 @@ namespace CoreHook
             Dispose();
         }
     }
-
 }


### PR DESCRIPTION
The PE optional header has an image magic type we can use to determine whether the image is 32-bit or 64-bit, so use that instead of the file header machine ID.