### PR TITLE
Update path checks for validating whether a CoreCLR runtime configuration exists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The project provides two options for configuring the runtime:
 (which is located next to `CoreHook.CoreLoad.dll` assembly in the CoreHook output directory) to initialize CoreCLR. 
 2. A global configuration file named `dotnet.runtimeconfig.json`.
 
-The host module will first attempt to use the local configuration file, then it will check for the the global configuration file and use that if it exists, and finally it will use the directory of the `CoreHook.CoreLoad.dll` assembly for resolving dependencies.
+The host module will first attempt to use the local configuration file, then it will check for the global configuration file and use that if it exists, and finally it will use the directory of the `CoreHook.CoreLoad.dll` assembly for resolving dependencies.
 
 The `runtimeconfig` file must contain the framework information for hosting .NET Core in the target application.
 When you build any .NET Core application, these files are generated to the output directory. [For more information on the
@@ -99,7 +99,7 @@ configuration options, see here](https://github.com/dotnet/cli/blob/master/Docum
 
 You can use the `CoreHook.FileMonitor.runtimeconfig.json` and `CoreHook.FileMonitor.runtimeconfig.dev.json` files found in your build output directory as references for creating the global or local configuration files.
 
-The runtime configuration file should look like the one below, where `additionalProbingPaths` contains file paths the host module can check for additional dependencies. This guide assumes you have installed the `2.2` runtime or SDK for both x86 and x64 architectures.
+The runtime configuration file should look like the one below, where `additionalProbingPaths` contains file paths the host module can check for additional dependencies. This guide assumes you have installed the `.NET Core 2.2` runtime or SDK for both x86 and x64 architectures.
 
 **Notice: Either replace `<user>` with your local computer user name or modify the paths to point to where your NuGet packages are installed. Take a look at `CoreHook.FileMonitor.runtimeconfig.dev.json` in the output directory to find your paths.**
 

--- a/examples/Common/CoreHook.Examples.Common/ModulesPathHelper.cs
+++ b/examples/Common/CoreHook.Examples.Common/ModulesPathHelper.cs
@@ -148,8 +148,8 @@ namespace CoreHook.Examples.Common
             if (string.IsNullOrWhiteSpace(coreRootPath) || !DoesDirectoryContainRuntimeConfiguration(coreRootPath))
             {
                 Console.WriteLine(is64BitProcess
-                    ? "CoreCLR root path was not set for 64-bit processes."
-                    : "CoreCLR root path was not set for 32-bit processes.");
+                    ? "CoreCLR configuration was not found for 64-bit processes."
+                    : "CoreCLR configuration was not found for 32-bit processes.");
                 return false;
             }
             return true;

--- a/examples/Common/CoreHook.Examples.Common/ModulesPathHelper.cs
+++ b/examples/Common/CoreHook.Examples.Common/ModulesPathHelper.cs
@@ -92,15 +92,26 @@ namespace CoreHook.Examples.Common
         }
 
         /// <summary>
-        /// Determine if the CoreLoad module has a runtime configuration file.
+        /// Determine if the application has a local CoreCLR runtime configuration file.
         /// </summary>
         /// <param name="applicationBase">The application base directory.</param>
-        /// <returns>True if there is a runtime configuration file for CoreLoad.</returns>
+        /// <returns>True if there the directory contains a runtime configuration file.</returns>
         private static bool HasLocalRuntimeConfiguration(string applicationBase)
         {
             // The configuration file should be named 'CoreHook.CoreLoad.runtimeconfig.json'
             return File.Exists(Path.Combine(applicationBase,
                 CoreLoadModule.Replace("dll", "runtimeconfig.json")));
+        }
+
+        /// <summary>
+        /// Determine if the path CoreCLR runtime configuration file.
+        /// </summary>
+        /// <param name="configurationBase">Directory that should contain a CoreCLR runtime configuration file.</param>
+        /// <returns>True if there the directory contains a runtime configuration file.</returns>
+        private static bool DoesDirectoryContainRuntimeConfiguration(string configurationBase)
+        {
+            // The configuration file should be named 'dotnet.runtimeconfig.json'
+            return File.Exists(Path.Combine(configurationBase, "dotnet.runtimeconfig.json"));
         }
 
         /// <summary>
@@ -134,7 +145,7 @@ namespace CoreHook.Examples.Common
             // Path to the directory containing the CoreCLR runtime configuration file.
             coreRootPath = GetCoreRootPath(is64BitProcess);
 
-            if (string.IsNullOrWhiteSpace(coreRootPath))
+            if (string.IsNullOrWhiteSpace(coreRootPath) || !DoesDirectoryContainRuntimeConfiguration(coreRootPath))
             {
                 Console.WriteLine(is64BitProcess
                     ? "CoreCLR root path was not set for 64-bit processes."


### PR DESCRIPTION
* Make sure the runtime configuration file exists before attempting to load start CoreCLR in a target process since loading will fail when the native coreload module doesn't find the file.

* Update readme to fix typos and make configuration details clearer