### PR TITLE
Update remote injection tests

### DIFF
--- a/src/CoreHook.Memory/Formats/PortableExecutable/DataDirectory.cs
+++ b/src/CoreHook.Memory/Formats/PortableExecutable/DataDirectory.cs
@@ -4,8 +4,8 @@ namespace CoreHook.Memory.Formats.PortableExecutable
 {
     internal struct DataDirectory
     {
-        internal uint VirtualAddress { get; }
-        internal uint Size { get; }
+        internal readonly uint VirtualAddress;
+        internal readonly uint Size;
 
         internal DataDirectory(BinaryReader reader, int offset)
         {

--- a/src/CoreHook/LocalHook.cs
+++ b/src/CoreHook/LocalHook.cs
@@ -102,11 +102,11 @@ namespace CoreHook
         {
             if (module == null)
             {
-                throw new ArgumentNullException(module);
+                throw new ArgumentNullException(nameof(module));
             }
             if (function == null)
             {
-                throw new ArgumentNullException(function);
+                throw new ArgumentNullException(nameof(function));
             }
 
             IntPtr functionAddress = NativeApi.DetourFindFunction(module, function);

--- a/tests/CoreHook.Tests/CoreHook.Tests.csproj
+++ b/tests/CoreHook.Tests/CoreHook.Tests.csproj
@@ -24,10 +24,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit.assert" Version="2.4.0" />
-    <PackageReference Include="xunit.core" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
+    <PackageReference Include="xunit.core" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/CoreHook.Tests/RemoteInjectionTest.cs
+++ b/tests/CoreHook.Tests/RemoteInjectionTest.cs
@@ -6,87 +6,67 @@ using CoreHook.Tests.Plugins.Shared;
 
 namespace CoreHook.Tests
 {
-    [Collection("Sequential")]
-    public class RemoteInjectionTest
+    [Collection("Remote Injection Tests")]
+    public class RemoteInjectionTests
     {
-        [Fact]
-        private void TestRemoteInject64()
+        [Theory]
+        [InlineData("System32")]
+        [InlineData("SysWOW64")]
+        private void TestRemoteInject64(string applicationFolder)
         {
-            const string TestHookLibrary = "CoreHook.Tests.SimpleParameterTest.dll";
-            const string TestMessage = "Berner";
+            const string testHookLibrary = "CoreHook.Tests.SimpleParameterTest.dll";
+            const string testMessage = "Berner";
 
             var testProcess = Resources.StartProcess(Path.Combine(
                             Environment.ExpandEnvironmentVariables("%Windir%"),
-                            "System32",
+                            applicationFolder,
                             "notepad.exe"
                         ));
 
+            System.Threading.Thread.Sleep(500);
+
             Resources.InjectDllIntoTarget(testProcess,
                Resources.GetTestDllPath(
-               TestHookLibrary
+               testHookLibrary
                ),
                Resources.GetUniquePipeName(),
-               TestMessage);
+               testMessage);
 
-            Assert.Equal(TestMessage, Resources.ReadFromProcess(testProcess));
+            Assert.Equal(testMessage, Resources.ReadFromProcess(testProcess));
 
             Resources.EndProcess(testProcess);
         }
     }
 
-    [Collection("Sequential")]
-    public class RemoteInjectionTest32
-    {
 
-        [Fact]
-        private void TestRemoteInject32()
-        {
-            const string TestHookLibrary = "CoreHook.Tests.SimpleParameterTest.dll";
-            const string TestMessage = "Berner";
-
-            var testProcess = Resources.StartProcess(Path.Combine(
-                            Environment.ExpandEnvironmentVariables("%Windir%"),
-                            "SysWOW64",
-                            "notepad.exe"
-                        ));
-
-            Resources.InjectDllIntoTarget(testProcess,
-               Resources.GetTestDllPath(
-               TestHookLibrary
-               ),
-               Resources.GetUniquePipeName(),
-               TestMessage);
-
-            Assert.Equal(TestMessage, Resources.ReadFromProcess(testProcess));
-
-            Resources.EndProcess(testProcess);
-        }
-    }
-
-    [Collection("Sequential")]
+    [Collection("Remote Injection Tests")]
     public class RemoteInjectionTestComplex
     {
-        [Fact]
-        private void TestRemotePluginComplexParameter()
+        [Theory]
+        [InlineData("System32")]
+        [InlineData("SysWOW64")]
+        private void TestRemotePluginComplexParameter(string applicationFolder)
         {
-            const string TestHookLibrary = "CoreHook.Tests.ComplexParameterTest.dll";
-            const string TestMessage = "Berner";
+            const string testHookLibrary = "CoreHook.Tests.ComplexParameterTest.dll";
+            const string testMessage = "Berner";
 
             var complexParameter = new ComplexParameter
             {
-                Message = TestMessage,
+                Message = testMessage,
                 HostProcessId = Process.GetCurrentProcess().Id
             };
 
             var testProcess = Resources.StartProcess(Path.Combine(
                             Environment.ExpandEnvironmentVariables("%Windir%"),
-                            "System32",
+                            applicationFolder,
                             "notepad.exe"
                         ));
 
+            System.Threading.Thread.Sleep(500);
+
             Resources.InjectDllIntoTarget(testProcess,
                Resources.GetTestDllPath(
-               TestHookLibrary
+               testHookLibrary
                ),
                Resources.GetUniquePipeName(),
                complexParameter);

--- a/tests/CoreHook.Tests/RemoteInjectionTest.cs
+++ b/tests/CoreHook.Tests/RemoteInjectionTest.cs
@@ -7,7 +7,7 @@ using CoreHook.Tests.Plugins.Shared;
 namespace CoreHook.Tests
 {
     [Collection("Remote Injection Tests")]
-    public class RemoteInjectionTests
+    public class RemoteInjectionTest
     {
         [Theory]
         [InlineData("System32")]
@@ -37,7 +37,6 @@ namespace CoreHook.Tests
             Resources.EndProcess(testProcess);
         }
     }
-
 
     [Collection("Remote Injection Tests")]
     public class RemoteInjectionTestComplex

--- a/tests/CoreHook.Tests/RemoteInjectionTest.cs
+++ b/tests/CoreHook.Tests/RemoteInjectionTest.cs
@@ -7,15 +7,15 @@ using CoreHook.Tests.Plugins.Shared;
 namespace CoreHook.Tests
 {
     [Collection("Remote Injection Tests")]
-    public class RemoteInjectionTest
+    public class RemoteInjectionTestSimpleParameter
     {
         [Theory]
         [InlineData("System32")]
         [InlineData("SysWOW64")]
-        private void TestRemoteInject64(string applicationFolder)
+        private void TestRemotePluginSimpleParameter(string applicationFolder)
         {
             const string testHookLibrary = "CoreHook.Tests.SimpleParameterTest.dll";
-            const string testMessage = "Berner";
+            const string remoteArgument = "Berner";
 
             var testProcess = Resources.StartProcess(Path.Combine(
                             Environment.ExpandEnvironmentVariables("%Windir%"),
@@ -30,16 +30,16 @@ namespace CoreHook.Tests
                testHookLibrary
                ),
                Resources.GetUniquePipeName(),
-               testMessage);
+               remoteArgument);
 
-            Assert.Equal(testMessage, Resources.ReadFromProcess(testProcess));
+            Assert.Equal(remoteArgument, Resources.ReadFromProcess(testProcess));
 
             Resources.EndProcess(testProcess);
         }
     }
 
     [Collection("Remote Injection Tests")]
-    public class RemoteInjectionTestComplex
+    public class RemoteInjectionTestComplexParameter
     {
         [Theory]
         [InlineData("System32")]
@@ -47,11 +47,11 @@ namespace CoreHook.Tests
         private void TestRemotePluginComplexParameter(string applicationFolder)
         {
             const string testHookLibrary = "CoreHook.Tests.ComplexParameterTest.dll";
-            const string testMessage = "Berner";
+            const string testMessageParameter = "Berner";
 
             var complexParameter = new ComplexParameter
             {
-                Message = testMessage,
+                Message = testMessageParameter,
                 HostProcessId = Process.GetCurrentProcess().Id
             };
 

--- a/tests/CoreHook.Tests/Windows/LocalHookTest.cs
+++ b/tests/CoreHook.Tests/Windows/LocalHookTest.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace CoreHook.Tests.Windows
 {
-    [Collection("Sequential")]
+    [Collection("Local Hook Tests")]
     public class LocalHookTest
     {
         [DllImport("kernel32.dll", SetLastError = true)]

--- a/tests/CoreHook.Tests/Windows/SymbolsTest.cs
+++ b/tests/CoreHook.Tests/Windows/SymbolsTest.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace CoreHook.Tests.Windows
 {
-    [Collection("Sequential")]
+    [Collection("Local Hook Tests")]
     public class SymbolsTest
     {
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode,
@@ -112,14 +112,14 @@ namespace CoreHook.Tests.Windows
         /// when the detour is called without skipping the detour barrier.
         /// </summary>
         [Fact]
-        public void DetourAPIAndInternalFunction()
+        public void DetourApiAndInternalFunction()
         {
             // Create the internal function and public API detours.
             using (var hookInternal = LocalHook.Create(
                  LocalHook.GetProcAddress("kernel32.dll", "InternalAddAtom"),
                  new InternalAddAtomDelegate(InternalAddAtomHook),
                  this))
-            using (var hookAPI = LocalHook.Create(
+            using (var hookApi = LocalHook.Create(
                 LocalHook.GetProcAddress("kernel32.dll", "AddAtomW"),
                 new AddAtomWDelegate(AddAtomHook),
                 this))
@@ -127,7 +127,7 @@ namespace CoreHook.Tests.Windows
                 hookInternal.ThreadACL.SetInclusiveACL(new int[] { 0 });
                 InternalAddAtomFunction = hookInternal.TargetAddress.ToFunction<InternalAddAtomDelegate>();
 
-                hookAPI.ThreadACL.SetInclusiveACL(new int[] { 0 });
+                hookApi.ThreadACL.SetInclusiveACL(new int[] { 0 });
 
                 _internalAddAtomCalled = false;
                 _addAtomCalled = false;
@@ -154,20 +154,20 @@ namespace CoreHook.Tests.Windows
         }
 
         [Fact]
-        public void DetourAPIAndInternalFunctionUsingBypassAddress()
+        public void DetourApiIAndInternalFunctionUsingBypassAddress()
         {
             using (var hookInternal = LocalHook.Create(
                 LocalHook.GetProcAddress("kernel32.dll", "InternalAddAtom"),
                 new InternalAddAtomDelegate(InternalAddAtomHook),
                 this))
-            using (var hookAPI = LocalHook.Create(
+            using (var hookApi = LocalHook.Create(
                 LocalHook.GetProcAddress("kernel32.dll", "AddAtomW"),
                 new AddAtomWDelegate(AddAtomHook),
                 this))
             {
                 hookInternal.ThreadACL.SetInclusiveACL(new int[] { 0 });
 
-                hookAPI.ThreadACL.SetInclusiveACL(new int[] { 0 });
+                hookApi.ThreadACL.SetInclusiveACL(new int[] { 0 });
 
                 InternalAddAtomFunction = hookInternal.OriginalAddress.ToFunction<InternalAddAtomDelegate>();
 


### PR DESCRIPTION
* Simplify the remote injection tests for testing 32-bit and 64-bit applications with CoreHook.
* Separate collections for the local hooking tests and the remote injection tests by giving them proper names instead of "Sequential". 
* Add a delay for the remote injection tests to give the application time to start before injecting the .NET runtime.