### PR TITLE
Refactor local hooking tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Thierry Bizimungu
+Copyright (c) Thierry Bizimungu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ $aumidList
  **Notes:** There is currently no way to set the proper access control on our pipes on the .NET Core platform and the issue is [being tracked here](https://github.com/dotnet/corefx/issues/31190) so we use P/Invoke to call `kernel32.dll!CreateNamedPipe` directly.
 
 ### Windows 10 IoT Core (ARM)
-**There is currently no ARM .NET Core SDK that runs on Windows 10 IoT Core, so you must publish the application from a platform with an SDK and copy it to your IoT Core device. [You can read more about the publishing process here.](https://github.com/dotnet/core/blob/master/samples/RaspberryPiInstructions.md)**
+**[Raspberry Pi itself is supported only as deployment target but there is an unsupported version of the SDK available as well. Read more about the publishing process by following this link.](https://github.com/dotnet/core/blob/master/samples/RaspberryPiInstructions.md)**
 
 For `Windows 10 IoT Core`, you can publish the application by running the `publish.ps1` [PowerShell script](#publishing-script).
 

--- a/examples/Uwp/CoreHook.Uwp.FileMonitor.Hook/EntryPoint.cs
+++ b/examples/Uwp/CoreHook.Uwp.FileMonitor.Hook/EntryPoint.cs
@@ -38,9 +38,9 @@ namespace CoreHook.Uwp.FileMonitor.Hook
             {
                 StartClient(pipeName);
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                ClientWriteLine(ex.ToString());
+                ClientWriteLine(e.ToString());
             }
         }
 
@@ -164,9 +164,9 @@ namespace CoreHook.Uwp.FileMonitor.Hook
                         }
                     }
                 }
-                catch (Exception ex)
+                catch (Exception e)
                 {
-                    ClientWriteLine(ex.ToString());
+                    ClientWriteLine(e.ToString());
                 }
             }
         }

--- a/examples/Win32/CoreHook.FileMonitor.Hook/EntryPoint.cs
+++ b/examples/Win32/CoreHook.FileMonitor.Hook/EntryPoint.cs
@@ -37,9 +37,9 @@ namespace CoreHook.FileMonitor.Hook
             {
                 StartClient(pipeName);
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                ClientWriteLine(ex.ToString());
+                ClientWriteLine(e.ToString());
             }
         }
 
@@ -176,9 +176,9 @@ namespace CoreHook.FileMonitor.Hook
                         }
                     }
                 }
-                catch (Exception ex)
+                catch (Exception e)
                 {
-                    ClientWriteLine(ex.ToString());
+                    ClientWriteLine(e.ToString());
                 }
             }
         }

--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
         internal const string Error_L1 = "api-ms-win-core-winrt-error-l1-1-0.dll";
         internal const string HttpApi = "httpapi.dll";
         internal const string IpHlpApi = "iphlpapi.dll";
+        internal const string KernelBase = "kernelbase.dll";
         internal const string Kernel32 = "kernel32.dll";
         internal const string Memory_L1_3 = "api-ms-win-core-memory-l1-1-3.dll";
         internal const string Mswsock = "mswsock.dll";

--- a/src/Common/src/Interop/Windows/kernel32/Interop.AddAtomW.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.AddAtomW.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Interop.Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+        internal static extern ushort AddAtomW(string lpString);        
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.Beep.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.Beep.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, SetLastError = true)]
+        internal static extern bool Beep(int frequency, int duration);
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.DeleteAtom.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.DeleteAtom.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Interop.Libraries.Kernel32, SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+        internal static extern ushort DeleteAtom(ushort nAtom);
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.FindAtomW.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.FindAtomW.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Interop.Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+        internal static extern ushort FindAtomW(string lpString);
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetAtomNameW.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetAtomNameW.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Interop.Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+        internal static extern uint GetAtomNameW(ushort nAtom, StringBuilder lpBuffer, int nSize);
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetTickCount64.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetTickCount64.cs
@@ -6,6 +6,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32)]
-        internal static extern uint GetVersion();
+        internal static extern ulong GetTickCount64();
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetVersion.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetVersion.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32)]
+        internal static extern uint GetVersion();
+    }
+}

--- a/src/Common/src/Interop/Windows/kernelbase/Interop.CompareStringW.cs
+++ b/src/Common/src/Interop/Windows/kernelbase/Interop.CompareStringW.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class KernelBase
+    {
+        [DllImport(Interop.Libraries.KernelBase, CharSet = CharSet.Unicode, SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+        internal static extern int CompareStringW(uint locale, uint dwCmpFlags, string lpString1, int cchCount1, string lpString2, int cchCount2);        
+    }
+}

--- a/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/RemoteInjector.cs
@@ -241,9 +241,9 @@ namespace CoreHook.BinaryInjection.RemoteInjection
                                 InjectionHelper.WaitForInjection(targetProcessId);
                             }
                         }
-                        catch (Exception ex)
+                        catch (Exception e)
                         {
-                            Console.WriteLine(ex.ToString());
+                            Console.WriteLine(e.ToString());
                         }
                     }
                 }

--- a/src/CoreHook.CoreLoad/Data/PluginConfiguration.cs
+++ b/src/CoreHook.CoreLoad/Data/PluginConfiguration.cs
@@ -50,10 +50,10 @@ namespace CoreHook.CoreLoad.Data
                     data.UnmanagedInfo.UserData,
                     data.UnmanagedInfo.UserDataSize);
             }
-            catch (Exception exception)
+            catch (Exception e)
             {
                 data.State = PluginInitializationState.Failed;
-                Debug.WriteLine(exception.ToString());
+                Debug.WriteLine(e.ToString());
             }
             return data;
         }

--- a/src/CoreHook.CoreLoad/DependencyResolver.cs
+++ b/src/CoreHook.CoreLoad/DependencyResolver.cs
@@ -46,9 +46,9 @@ namespace CoreHook.CoreLoad
 
                 _loadContext.Resolving += OnResolving;
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                Log($"AssemblyResolver error: {ex}");
+                Log($"AssemblyResolver error: {e}");
             }
         }
 
@@ -96,9 +96,9 @@ namespace CoreHook.CoreLoad
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                Log($"OnResolving error: {ex}");
+                Log($"OnResolving error: {e}");
             }
             return null;
         }

--- a/src/CoreHook.CoreLoad/PluginLoader.cs
+++ b/src/CoreHook.CoreLoad/PluginLoader.cs
@@ -81,9 +81,9 @@ namespace CoreHook.CoreLoad
                 Log(outOfRangeEx.ToString());
                 throw;
             }
-            catch (Exception exception)
+            catch (Exception e)
             {
-                Log(exception.ToString());
+                Log(e.ToString());
             }
             return (int)PluginInitializationState.Failed;
         }

--- a/src/CoreHook.IPC/NamedPipes/NamedPipeClient.cs
+++ b/src/CoreHook.IPC/NamedPipes/NamedPipeClient.cs
@@ -51,9 +51,9 @@ namespace CoreHook.IPC.NamedPipes
 
                 _pipeStream.Connect();
             }
-            catch (IOException ex)
+            catch (IOException e)
             {
-                Console.WriteLine(ex.ToString());
+                Console.WriteLine(e.ToString());
                 return false;
             }
 

--- a/src/CoreHook/LocalHook.cs
+++ b/src/CoreHook/LocalHook.cs
@@ -146,14 +146,14 @@ namespace CoreHook
                     GCHandle.ToIntPtr(hook.SelfHandle),
                     hook.Handle);
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
                 Marshal.FreeCoTaskMem(hook.Handle);
                 hook.Handle = IntPtr.Zero;
 
                 hook.SelfHandle.Free();
 
-                throw ex;
+                throw e;
             }
 
             hook.AccessControl = new HookAccessControl(hook.Handle);
@@ -189,14 +189,14 @@ namespace CoreHook
                     callback,
                     hook.Handle);
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
                 Marshal.FreeCoTaskMem(hook.Handle);
                 hook.Handle = IntPtr.Zero;
 
                 hook.SelfHandle.Free();
 
-                throw ex;
+                throw e;
             }
 
             hook.AccessControl = new HookAccessControl(hook.Handle);
@@ -223,14 +223,14 @@ namespace CoreHook
                     callback,
                     hook.Handle);
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
                 Marshal.FreeCoTaskMem(hook.Handle);
                 hook.Handle = IntPtr.Zero;
 
                 hook.SelfHandle.Free();
 
-                throw ex;
+                throw e;
             }
 
             hook.AccessControl = new HookAccessControl(hook.Handle);

--- a/src/CoreHook/LocalHook{T}.cs
+++ b/src/CoreHook/LocalHook{T}.cs
@@ -48,14 +48,14 @@ namespace CoreHook
                     callback,
                     hook.Handle);
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
                 Marshal.FreeCoTaskMem(hook.Handle);
                 hook.Handle = IntPtr.Zero;
 
                 hook.SelfHandle.Free();
 
-                throw ex;
+                throw e;
             }
 
             hook.AccessControl = new HookAccessControl(hook.Handle);
@@ -92,14 +92,14 @@ namespace CoreHook
                     GCHandle.ToIntPtr(hook.SelfHandle),
                     hook.Handle);
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
                 Marshal.FreeCoTaskMem(hook.Handle);
                 hook.Handle = IntPtr.Zero;
 
                 hook.SelfHandle.Free();
 
-                throw ex;
+                throw e;
             }
 
             hook.AccessControl = new HookAccessControl(hook.Handle);

--- a/tests/CoreHook.Tests/CoreHook.Tests.csproj
+++ b/tests/CoreHook.Tests/CoreHook.Tests.csproj
@@ -41,4 +41,10 @@
     <ProjectReference Include="..\plugins\CoreHook.Tests.Plugins.Shared\CoreHook.Tests.Plugins.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+  </ItemGroup>   
+
 </Project>

--- a/tests/CoreHook.Tests/CoreHook.Tests.csproj
+++ b/tests/CoreHook.Tests/CoreHook.Tests.csproj
@@ -45,6 +45,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.Beep.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.Beep.cs</Link>
+    </Compile>    
   </ItemGroup>   
 
 </Project>

--- a/tests/CoreHook.Tests/CoreHook.Tests.csproj
+++ b/tests/CoreHook.Tests/CoreHook.Tests.csproj
@@ -45,15 +45,30 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernelbase\Interop.CompareStringW.cs">
+      <Link>Common\Interop\Windows\kernelbase\Interop.CompareStringW.cs</Link>
+    </Compile>    
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.AddAtomW.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.AddAtomW.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.Beep.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.Beep.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.DeleteAtom.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.DeleteAtom.cs</Link>
+    </Compile>    
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FindAtomW.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.FindAtomW.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetVersion.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.GetVersion.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetTickCount64.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.GetTickCount64.cs</Link>
-    </Compile>    
-  </ItemGroup>   
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetAtomNameW.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GetAtomNameW.cs</Link>
+    </Compile>
+  </ItemGroup>
 
 </Project>

--- a/tests/CoreHook.Tests/CoreHook.Tests.csproj
+++ b/tests/CoreHook.Tests/CoreHook.Tests.csproj
@@ -50,6 +50,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetVersion.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.GetVersion.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetTickCount64.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GetTickCount64.cs</Link>
     </Compile>    
   </ItemGroup>   
 

--- a/tests/CoreHook.Tests/CoreHook.Tests.csproj
+++ b/tests/CoreHook.Tests/CoreHook.Tests.csproj
@@ -47,6 +47,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.Beep.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.Beep.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetVersion.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GetVersion.cs</Link>
     </Compile>    
   </ItemGroup>   
 

--- a/tests/CoreHook.Tests/UserDataFormatterTest.cs
+++ b/tests/CoreHook.Tests/UserDataFormatterTest.cs
@@ -10,13 +10,13 @@ namespace CoreHook.Tests
         [Serializable]
         internal class  UserDataFormatterTestClass
         {
-            public int IntegerMember;
+            internal int IntegerMember;
         }
 
         [Fact]
         public void ShouldThrowNullExceptionWhenSerializingNullObject()
         {
-            IUserDataFormatter formatter = new UserDataBinaryFormatter();
+            IUserDataFormatter formatter = CreateFormatter();
             Stream serializationStream = new MemoryStream();
             object objectToSerialize = null;
 
@@ -26,7 +26,7 @@ namespace CoreHook.Tests
         [Fact]
         public void ShouldThrowNullExceptionWhenSerializingWithNullStream()
         {
-            IUserDataFormatter formatter = new UserDataBinaryFormatter();
+            IUserDataFormatter formatter = CreateFormatter();
             Stream serializationStream = null;
             var objectToSerialize = new byte[4];
 
@@ -34,9 +34,9 @@ namespace CoreHook.Tests
         }
 
         [Fact]
-        public void ShouldThrowNullExceptionWhenSerializingWithNullStreamAndNUllObject()
+        public void ShouldThrowNullExceptionWhenSerializingWithNullStreamAndNullObject()
         {
-            IUserDataFormatter formatter = new UserDataBinaryFormatter();
+            IUserDataFormatter formatter = CreateFormatter();
             Stream serializationStream = null;
             object objectToSerialize = null;
 
@@ -46,7 +46,7 @@ namespace CoreHook.Tests
         [Fact]
         public void ShouldSerializeClassToStream()
         {
-            IUserDataFormatter formatter = new UserDataBinaryFormatter();
+            IUserDataFormatter formatter = CreateFormatter();
 
             using (Stream serializationStream = new MemoryStream())
             {
@@ -60,7 +60,7 @@ namespace CoreHook.Tests
         [Fact]
         public void ShouldSerializeAndDeserializeClassWithStream()
         {
-            IUserDataFormatter formatter = new UserDataBinaryFormatter();
+            IUserDataFormatter formatter = CreateFormatter();
             const int integerMemberValue = 1;
 
             using (Stream serializationStream = new MemoryStream())
@@ -77,5 +77,7 @@ namespace CoreHook.Tests
                 Assert.Equal(integerMemberValue, deserializedObject.IntegerMember);
             }
         }
+
+        private static IUserDataFormatter CreateFormatter() => new UserDataBinaryFormatter();
     }
 }

--- a/tests/CoreHook.Tests/Windows/LocalHookTest.cs
+++ b/tests/CoreHook.Tests/Windows/LocalHookTest.cs
@@ -7,7 +7,7 @@ namespace CoreHook.Tests.Windows
     [Collection("Local Hook Tests")]
     public class LocalHookTest
     {
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [DllImport(Interop.Libraries.Kernel32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool Beep(uint dwFreq, uint dwDuration);
 
@@ -30,7 +30,7 @@ namespace CoreHook.Tests.Windows
         public void DetourIsInstalled()
         {
             using (var hook = LocalHook.Create(
-                LocalHook.GetProcAddress("kernel32.dll", "Beep"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "Beep"),
                 new BeepDelegate(BeepHook),
                 this))
             {
@@ -46,7 +46,7 @@ namespace CoreHook.Tests.Windows
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         public delegate uint GetTickCountDelegate();
-        [DllImport("kernel32.dll")]
+        [DllImport(Interop.Libraries.Kernel32)]
         public static extern uint GetTickCount();
         private bool _getTickCountCalled;
 
@@ -60,7 +60,7 @@ namespace CoreHook.Tests.Windows
         public void DetourIsBypassedByOriginalFunction()
         {
             using (var hook = LocalHook.Create(
-                LocalHook.GetProcAddress("kernel32.dll", "GetTickCount"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "GetTickCount"),
                 new GetTickCountDelegate(Detour_GetTickCount),
                 this))
             {
@@ -78,7 +78,7 @@ namespace CoreHook.Tests.Windows
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         public delegate long GetTickCount64Delegate();
-        [DllImport("kernel32.dll")]
+        [DllImport(Interop.Libraries.Kernel32)]
         public static extern long GetTickCount64();
         private bool _getTickCount64Called;
 
@@ -92,7 +92,7 @@ namespace CoreHook.Tests.Windows
         public void DetourCanBeBypassedAfterDetourCall()
         {
             using (var hook = LocalHook.Create(
-                LocalHook.GetProcAddress("kernel32.dll", "GetTickCount64"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "GetTickCount64"),
                 new GetTickCount64Delegate(Detour_GetTickCount64),
                 this))
             {
@@ -118,7 +118,7 @@ namespace CoreHook.Tests.Windows
         public void Invalid_LocalHook_Create_Detour_Delegate_Throws_ArgumentNUllException()
         {
             Assert.Throws<ArgumentNullException>(() => LocalHook.Create(
-                LocalHook.GetProcAddress("kernel32.dll", "CreateFileW"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "CreateFileW"),
                 null,
                 this));
         }
@@ -136,7 +136,7 @@ namespace CoreHook.Tests.Windows
         public void TestInvalidDetourCallback()
         {
             using (var hook = LocalHook.Create(
-                LocalHook.GetProcAddress("kernel32.dll", "QueryPerformanceCounter"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "QueryPerformanceCounter"),
                 new QueryPerformanceCounterDelegate(Detour_QueryPerformanceCounter),
                 null))
             {    
@@ -150,14 +150,14 @@ namespace CoreHook.Tests.Windows
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         public delegate uint GetVersionDelegate();
 
-        [DllImport("kernel32.dll")]
+        [DllImport(Interop.Libraries.Kernel32)]
         public static extern uint GetVersion();
 
         [Fact]
         public void ShouldEnableHookWithProperty()
         {
             using (var hook = HookFactory.CreateHook<GetVersionDelegate>(
-                LocalHook.GetProcAddress("kernel32.dll", "GetVersion"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "GetVersion"),
                 GetVersionDetour, this))
             {
                 // Enable the hook for all threads

--- a/tests/CoreHook.Tests/Windows/LocalHookTest.cs
+++ b/tests/CoreHook.Tests/Windows/LocalHookTest.cs
@@ -7,21 +7,17 @@ namespace CoreHook.Tests.Windows
     [Collection("Local Hook Tests")]
     public class LocalHookTest
     {
-        [DllImport(Interop.Libraries.Kernel32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool Beep(uint dwFreq, uint dwDuration);
-
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private delegate bool BeepDelegate(uint dwFreq, uint dwDuration);
+        private delegate bool BeepDelegate(int dwFreq, int dwDuration);
 
         private bool _beepHookCalled;
 
         [return: MarshalAs(UnmanagedType.Bool)]
-        private bool BeepHook(uint dwFreq, uint dwDuration)
+        private bool BeepHook(int dwFreq, int dwDuration)
         {
             _beepHookCalled = true;
 
-            Beep(dwFreq, dwDuration);
+            Interop.Kernel32.Beep(dwFreq, dwDuration);
 
             return false;
         }
@@ -38,7 +34,7 @@ namespace CoreHook.Tests.Windows
 
                 hook.ThreadACL.SetInclusiveACL(new int[] { 0 });
 
-                Assert.False(Beep(100, 100));
+                Assert.False(Interop.Kernel32.Beep(100, 100));
 
                 Assert.True(_beepHookCalled);
             }
@@ -46,13 +42,16 @@ namespace CoreHook.Tests.Windows
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         public delegate uint GetTickCountDelegate();
+
         [DllImport(Interop.Libraries.Kernel32)]
         public static extern uint GetTickCount();
+
         private bool _getTickCountCalled;
 
         private uint Detour_GetTickCount()
         {
             _getTickCountCalled = true;
+
             return 0;
         }
 
@@ -78,13 +77,16 @@ namespace CoreHook.Tests.Windows
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         public delegate long GetTickCount64Delegate();
+
         [DllImport(Interop.Libraries.Kernel32)]
         public static extern long GetTickCount64();
+
         private bool _getTickCount64Called;
 
         private long Detour_GetTickCount64()
         {
             _getTickCount64Called = true;
+
             return 0;
         }
 
@@ -123,7 +125,7 @@ namespace CoreHook.Tests.Windows
                 this));
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate bool QueryPerformanceCounterDelegate(out long performanceCount);
 
         private bool Detour_QueryPerformanceCounter(out long performanceCount)
@@ -183,6 +185,7 @@ namespace CoreHook.Tests.Windows
                 Assert.NotEqual<uint>(0, hook.Target());
             }
         }
+
         private uint GetVersionDetour()
         {
             return 0;

--- a/tests/CoreHook.Tests/Windows/LocalHookTest.cs
+++ b/tests/CoreHook.Tests/Windows/LocalHookTest.cs
@@ -13,21 +13,20 @@ namespace CoreHook.Tests.Windows
         private bool _beepHookCalled;
 
         [return: MarshalAs(UnmanagedType.Bool)]
-        private bool BeepHook(int dwFreq, int dwDuration)
+        private bool Detour_Beep(int dwFreq, int dwDuration)
         {
             _beepHookCalled = true;
 
             Interop.Kernel32.Beep(dwFreq, dwDuration);
-
             return false;
         }
 
         [Fact]
-        public void ShouldIntallDetourToFunctionAddress()
+        public void ShouldInstallDetourToFunctionAddress()
         {
             using (var hook = LocalHook.Create(
                 LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "Beep"),
-                new BeepDelegate(BeepHook),
+                new BeepDelegate(Detour_Beep),
                 this))
             {
                 _beepHookCalled = false;
@@ -128,6 +127,7 @@ namespace CoreHook.Tests.Windows
         private bool Detour_QueryPerformanceCounter(out long performanceCount)
         {
             performanceCount = 0;
+
             return false;
         }
 

--- a/tests/CoreHook.Tests/Windows/LocalHookTest.cs
+++ b/tests/CoreHook.Tests/Windows/LocalHookTest.cs
@@ -152,9 +152,6 @@ namespace CoreHook.Tests.Windows
         [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         public delegate uint GetVersionDelegate();
 
-        [DllImport(Interop.Libraries.Kernel32)]
-        public static extern uint GetVersion();
-
         [Fact]
         public void ShouldEnableHookWithProperty()
         {
@@ -164,31 +161,28 @@ namespace CoreHook.Tests.Windows
             {
                 // Enable the hook for all threads
                 hook.Enabled = true;
-                Assert.Equal<uint>(0, GetVersion());
+                Assert.Equal<uint>(0, Interop.Kernel32.GetVersion());
                 Assert.Equal<uint>(0, hook.Target());
 
                 // Disable the hook for all threads
                 hook.Enabled = false;
-                Assert.NotEqual<uint>(0, GetVersion());
+                Assert.NotEqual<uint>(0, Interop.Kernel32.GetVersion());
                 Assert.NotEqual<uint>(0, hook.Target());
                 Assert.NotEqual<uint>(0, hook.Original());
 
                 // Enable the hook for the current thread
                 hook.ThreadACL.SetInclusiveACL(new int[1]);
-                Assert.Equal<uint>(0, GetVersion());
+                Assert.Equal<uint>(0, Interop.Kernel32.GetVersion());
                 Assert.Equal<uint>(0, hook.Target());
                 Assert.NotEqual<uint>(0, hook.Original());
                 
                 // Disable the hook for the current thread
                 hook.ThreadACL.SetExclusiveACL(new int[1]);
-                Assert.NotEqual<uint>(0, GetVersion());
+                Assert.NotEqual<uint>(0, Interop.Kernel32.GetVersion());
                 Assert.NotEqual<uint>(0, hook.Target());
             }
         }
 
-        private uint GetVersionDetour()
-        {
-            return 0;
-        }  
+        private uint GetVersionDetour() => 0;
     }
 }

--- a/tests/CoreHook.Tests/Windows/SymbolsTest.cs
+++ b/tests/CoreHook.Tests/Windows/SymbolsTest.cs
@@ -8,22 +8,22 @@ namespace CoreHook.Tests.Windows
     [Collection("Local Hook Tests")]
     public class SymbolsTest
     {
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode,
+        [DllImport(Interop.Libraries.Kernel32, CharSet = CharSet.Unicode,
             SetLastError = true,
             CallingConvention = CallingConvention.StdCall)]
         private static extern ushort AddAtomW(string lpString);
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode,
+        [DllImport(Interop.Libraries.Kernel32, CharSet = CharSet.Unicode,
             SetLastError = true,
             CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetAtomNameW(ushort nAtom, StringBuilder lpBuffer, int nSize);
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode,
+        [DllImport(Interop.Libraries.Kernel32, CharSet = CharSet.Unicode,
             SetLastError = true,
             CallingConvention = CallingConvention.StdCall)]
         private static extern ushort DeleteAtom(ushort nAtom);
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode,
+        [DllImport(Interop.Libraries.Kernel32, CharSet = CharSet.Unicode,
             SetLastError = true,
             CallingConvention = CallingConvention.StdCall)]
         private static extern ushort FindAtomW(string lpString);
@@ -78,7 +78,7 @@ namespace CoreHook.Tests.Windows
         public void DetourInternalFunction()
         {
             using (var hook = LocalHook.Create(
-                LocalHook.GetProcAddress("kernel32.dll", "InternalAddAtom"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "InternalAddAtom"),
                 new InternalAddAtomDelegate(InternalAddAtomHook),
                 this))
             {
@@ -116,11 +116,11 @@ namespace CoreHook.Tests.Windows
         {
             // Create the internal function and public API detours.
             using (var hookInternal = LocalHook.Create(
-                 LocalHook.GetProcAddress("kernel32.dll", "InternalAddAtom"),
+                 LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "InternalAddAtom"),
                  new InternalAddAtomDelegate(InternalAddAtomHook),
                  this))
             using (var hookApi = LocalHook.Create(
-                LocalHook.GetProcAddress("kernel32.dll", "AddAtomW"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "AddAtomW"),
                 new AddAtomWDelegate(AddAtomHook),
                 this))
             {
@@ -157,11 +157,11 @@ namespace CoreHook.Tests.Windows
         public void DetourApiIAndInternalFunctionUsingBypassAddress()
         {
             using (var hookInternal = LocalHook.Create(
-                LocalHook.GetProcAddress("kernel32.dll", "InternalAddAtom"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "InternalAddAtom"),
                 new InternalAddAtomDelegate(InternalAddAtomHook),
                 this))
             using (var hookApi = LocalHook.Create(
-                LocalHook.GetProcAddress("kernel32.dll", "AddAtomW"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "AddAtomW"),
                 new AddAtomWDelegate(AddAtomHook),
                 this))
             {
@@ -199,7 +199,7 @@ namespace CoreHook.Tests.Windows
         public void DetourApiAndInternalFunctionUsingInterfaceBypassAddress()
         {
             using (var hookInternal = HookFactory.CreateHook<InternalFindAtom>(
-                LocalHook.GetProcAddress("kernel32.dll", "InternalFindAtom"),
+                LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "InternalFindAtom"),
                 InternalFindAtom_Hook,
                 this))
             {
@@ -263,7 +263,7 @@ namespace CoreHook.Tests.Windows
             _GetCurrentNlsCacheCalled = false;
 
             using (var hook = LocalHook.Create(
-                LocalHook.GetProcAddress("kernelbase.dll", "GetCurrentNlsCache"),
+                LocalHook.GetProcAddress(Interop.Libraries.KernelBase, "GetCurrentNlsCache"),
                 new GetCurrentNlsCacheDelegate(GetCurrentNlsCacheHook),
                 this))
             {
@@ -289,7 +289,7 @@ namespace CoreHook.Tests.Windows
         [Fact]
         public void Find_Invalid_Export_Function_Throws_MissingMethodException()
         {
-            Assert.Throws<MissingMethodException>(() => LocalHook.GetProcAddress("kernel32.dll", "ThisFunctionDoesNotExist"));
+            Assert.Throws<MissingMethodException>(() => LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "ThisFunctionDoesNotExist"));
         }
 
         [Fact]


### PR DESCRIPTION
* Refactor classes for testing API hooks and internal function hooks using symbol lookup.
* Make test code more consistent.
* Use the suggested Common Interop directory structure to remove API export definitions from the test classes and into their own Interop.* files.
* Move user data formatter class creation into a single method code to avoid code repetition. 