### PR TITLE
Rename generic message classes

### DIFF
--- a/src/CoreHook.BinaryInjection/RemoteInjection/InjectionHelper.cs
+++ b/src/CoreHook.BinaryInjection/RemoteInjection/InjectionHelper.cs
@@ -33,7 +33,7 @@ namespace CoreHook.BinaryInjection.RemoteInjection
         /// </summary>
         /// <param name="message">The message to process.</param>
         /// <param name="channel">The server communication channel.</param>
-        private static void HandleMessage(IMessage message, ITransportChannel channel)
+        private static void HandleMessage(IStringMessage message, ITransportChannel channel)
         {
             switch (message.Header)
             {

--- a/src/CoreHook.IPC/Handlers/MessageHandler.cs
+++ b/src/CoreHook.IPC/Handlers/MessageHandler.cs
@@ -22,12 +22,12 @@ namespace CoreHook.IPC.Handlers
         }
 
         /// <inheritdoc />
-        public IMessage Read() => _messageReader.Read();
+        public IStringMessage Read() => _messageReader.Read();
 
         /// <inheritdoc />
-        public bool TryWrite(IMessage message) => _messageWriter.TryWrite(message);
+        public bool TryWrite(IStringMessage message) => _messageWriter.TryWrite(message);
 
         /// <inheritdoc />
-        public void Write(IMessage message) => _messageWriter.Write(message);
+        public void Write(IStringMessage message) => _messageWriter.Write(message);
     }
 }

--- a/src/CoreHook.IPC/IMessageReader.cs
+++ b/src/CoreHook.IPC/IMessageReader.cs
@@ -11,6 +11,6 @@ namespace CoreHook.IPC
         /// Read an incoming message.
         /// </summary>
         /// <returns>A message from a remote process.</returns>
-        IMessage Read();
+        IStringMessage Read();
     }
 }

--- a/src/CoreHook.IPC/IMessageWriter.cs
+++ b/src/CoreHook.IPC/IMessageWriter.cs
@@ -12,11 +12,11 @@ namespace CoreHook.IPC
         /// </summary>
         /// <param name="message">The message to send.</param>
         /// <returns>True if the message was sent successfully.</returns>
-        bool TryWrite(IMessage message);
+        bool TryWrite(IStringMessage message);
         /// <summary>
         /// Send a message with no feedback on whether it was sent successfully.
         /// </summary>
         /// <param name="message">The message to send.</param>
-        void Write(IMessage message);
+        void Write(IStringMessage message);
     }
 }

--- a/src/CoreHook.IPC/MessageReader.cs
+++ b/src/CoreHook.IPC/MessageReader.cs
@@ -20,7 +20,7 @@ namespace CoreHook.IPC
         }
 
         /// <inheritdoc />
-        public IMessage Read()
+        public IStringMessage Read()
         {
             try
             {

--- a/src/CoreHook.IPC/MessageReader.cs
+++ b/src/CoreHook.IPC/MessageReader.cs
@@ -24,7 +24,7 @@ namespace CoreHook.IPC
         {
             try
             {
-                return Message.FromString(_reader.ReadLine());
+                return StringMessage.FromString(_reader.ReadLine());
             }
             catch (IOException)
             {

--- a/src/CoreHook.IPC/MessageWriter.cs
+++ b/src/CoreHook.IPC/MessageWriter.cs
@@ -20,7 +20,7 @@ namespace CoreHook.IPC
         }
 
         /// <inheritdoc />
-        public bool TryWrite(IMessage message)
+        public bool TryWrite(IStringMessage message)
         {
             try
             {
@@ -34,7 +34,7 @@ namespace CoreHook.IPC
         }
 
         /// <inheritdoc />
-        public void Write(IMessage message)
+        public void Write(IStringMessage message)
         {
             Write(message.ToString());
         }

--- a/src/CoreHook.IPC/Messages/IStringMessage.cs
+++ b/src/CoreHook.IPC/Messages/IStringMessage.cs
@@ -4,7 +4,7 @@ namespace CoreHook.IPC.Messages
     /// <summary>
     /// Defines a message that can be sent and received between processes.
     /// </summary>
-    public interface IMessage
+    public interface IStringMessage
     {
         /// <summary>
         /// The message's properties, such as message type.

--- a/src/CoreHook.IPC/Messages/InjectionCompleteNotification.cs
+++ b/src/CoreHook.IPC/Messages/InjectionCompleteNotification.cs
@@ -17,17 +17,17 @@ namespace CoreHook.IPC.Messages
             RequestData = new InjectionCompleteMessage(didComplete, processId);
         }
 
-        public IMessage CreateMessage()
+        public IStringMessage CreateMessage()
         {
             return new StringMessage(InjectionComplete, RequestData.ToMessage());
         }
 
-        public static IMessage CreateMessage(int processId, bool didComplete)
+        public static IStringMessage CreateMessage(int processId, bool didComplete)
         {
             return new InjectionCompleteNotification(processId, didComplete).CreateMessage();
         }
 
-        public static InjectionCompleteMessage ParseMessage(IMessage message)
+        public static InjectionCompleteMessage ParseMessage(IStringMessage message)
         {
             return InjectionCompleteMessage.FromBody(message.Body);
         }

--- a/src/CoreHook.IPC/Messages/InjectionCompleteNotification.cs
+++ b/src/CoreHook.IPC/Messages/InjectionCompleteNotification.cs
@@ -19,7 +19,7 @@ namespace CoreHook.IPC.Messages
 
         public IMessage CreateMessage()
         {
-            return new Message(InjectionComplete, RequestData.ToMessage());
+            return new StringMessage(InjectionComplete, RequestData.ToMessage());
         }
 
         public static IMessage CreateMessage(int processId, bool didComplete)

--- a/src/CoreHook.IPC/Messages/LogMessageNotification.cs
+++ b/src/CoreHook.IPC/Messages/LogMessageNotification.cs
@@ -38,7 +38,7 @@ namespace CoreHook.IPC.Messages
         /// Serialize the current message data to message class.
         /// </summary>
         /// <returns></returns>
-        public IMessage CreateMessage()
+        public IStringMessage CreateMessage()
         {
             return new StringMessage(Message, RequestData.ToMessage());
         }
@@ -49,7 +49,7 @@ namespace CoreHook.IPC.Messages
         /// <param name="level">The log message type.</param>
         /// <param name="message">The message data.</param>
         /// <returns>A new instance of a class representing a log message.</returns>
-        public static IMessage CreateMessage(LogLevel level, string message)
+        public static IStringMessage CreateMessage(LogLevel level, string message)
         {
             return new LogMessageNotification(level, message).CreateMessage();
         }
@@ -59,7 +59,7 @@ namespace CoreHook.IPC.Messages
         /// </summary>
         /// <param name="message">The message data.</param>
         /// <returns>A new instance of a class representing a log message.</returns>
-        public static LogMessage ParseMessage(IMessage message)
+        public static LogMessage ParseMessage(IStringMessage message)
         {
             return LogMessage.FromBody(message.Body);
         }

--- a/src/CoreHook.IPC/Messages/LogMessageNotification.cs
+++ b/src/CoreHook.IPC/Messages/LogMessageNotification.cs
@@ -40,7 +40,7 @@ namespace CoreHook.IPC.Messages
         /// <returns></returns>
         public IMessage CreateMessage()
         {
-            return new Message(Message, RequestData.ToMessage());
+            return new StringMessage(Message, RequestData.ToMessage());
         }
 
         /// <summary>

--- a/src/CoreHook.IPC/Messages/StringMessage.cs
+++ b/src/CoreHook.IPC/Messages/StringMessage.cs
@@ -4,7 +4,7 @@ namespace CoreHook.IPC.Messages
     /// <summary>
     /// A representation of data containing information to be communicated between a client and server.
     /// </summary>
-    public class Message : CustomMessage, IMessage
+    public class StringMessage : CustomMessage, IMessage
     {
         /// <inheritdoc />
         public string Header { get; }
@@ -12,11 +12,11 @@ namespace CoreHook.IPC.Messages
         public string Body { get; }
 
         /// <summary>
-        /// Initialize a new instance of the <see cref="Message"/> class.
+        /// Initialize a new instance of the <see cref="StringMessage"/> class.
         /// </summary>
         /// <param name="header">The message properties.</param>
         /// <param name="body">The message data.</param>
-        public Message(string header, string body)
+        public StringMessage(string header, string body)
         {
             Header = header;
             Body = body;
@@ -40,7 +40,7 @@ namespace CoreHook.IPC.Messages
                     body = parts[1];
                 }
             }
-            return new Message(header, body);
+            return new StringMessage(header, body);
         }
 
         /// <inheritdoc />

--- a/src/CoreHook.IPC/Messages/StringMessage.cs
+++ b/src/CoreHook.IPC/Messages/StringMessage.cs
@@ -4,7 +4,7 @@ namespace CoreHook.IPC.Messages
     /// <summary>
     /// A representation of data containing information to be communicated between a client and server.
     /// </summary>
-    public class StringMessage : CustomMessage, IMessage
+    public class StringMessage : CustomMessage, IStringMessage
     {
         /// <inheritdoc />
         public string Header { get; }
@@ -27,7 +27,7 @@ namespace CoreHook.IPC.Messages
         /// </summary>
         /// <param name="message">The message data.</param>
         /// <returns>A new instance of the message class.</returns>
-        public static IMessage FromString(string message)
+        public static IStringMessage FromString(string message)
         {
             string header = null;
             string body = null;

--- a/src/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
+++ b/src/CoreHook.IPC/NamedPipes/NamedPipeServer.cs
@@ -49,7 +49,7 @@ namespace CoreHook.IPC.NamedPipes
         /// <param name="platform">Method for initializing a new pipe-based server.</param>
         /// <param name="handleRequest">Event handler called when receiving a new message from a client.</param>
         /// <returns>An instance of the new pipe server.</returns>
-        public static INamedPipe StartNewServer(string pipeName, IPipePlatform platform, Action<IMessage, ITransportChannel> handleRequest)
+        public static INamedPipe StartNewServer(string pipeName, IPipePlatform platform, Action<IStringMessage, ITransportChannel> handleRequest)
         {
             return CreateNewServer(pipeName, platform, connection => HandleTransportConnection(connection, handleRequest));
         }
@@ -84,7 +84,7 @@ namespace CoreHook.IPC.NamedPipes
             return pipeServer;
         }
 
-        private static void HandleTransportConnection(ITransportChannel channel, Action<IMessage, ITransportChannel> handleRequest)
+        private static void HandleTransportConnection(ITransportChannel channel, Action<IStringMessage, ITransportChannel> handleRequest)
         {
             var connection = channel.Connection;
 

--- a/tests/CoreHook.Tests/InjectionHelperTest.cs
+++ b/tests/CoreHook.Tests/InjectionHelperTest.cs
@@ -81,7 +81,7 @@ namespace CoreHook.Tests
             return new PipePlatformBase();
         }
 
-        private static bool SendPipeMessage(IMessageWriter writer, IMessage message)
+        private static bool SendPipeMessage(IMessageWriter writer, IStringMessage message)
         {
             return writer.TryWrite(message);
         }

--- a/tests/CoreHook.Tests/NamedPipeTest.cs
+++ b/tests/CoreHook.Tests/NamedPipeTest.cs
@@ -113,7 +113,7 @@ namespace CoreHook.Tests
             return new NamedPipeClient(pipeName);
         }
 
-        private static INamedPipe CreateServer(string namedPipeName, IPipePlatform pipePlatform, Action<IMessage, ITransportChannel> handleRequest)
+        private static INamedPipe CreateServer(string namedPipeName, IPipePlatform pipePlatform, Action<IStringMessage, ITransportChannel> handleRequest)
         {
             return NamedPipeServer.StartNewServer(namedPipeName, pipePlatform, handleRequest);
         }
@@ -132,7 +132,7 @@ namespace CoreHook.Tests
             return SendPipeMessage(messageHandler, StringMessage.FromString(message));
         }
 
-        private static bool SendPipeMessage(IMessageHandler messageHandler, IMessage message)
+        private static bool SendPipeMessage(IMessageHandler messageHandler, IStringMessage message)
         {
             return messageHandler.TryWrite(message);
         }
@@ -142,12 +142,12 @@ namespace CoreHook.Tests
             return messageHandler.Read().ToString();
         }
 
-        private static IMessage ReadMessage(IMessageHandler messageHandler)
+        private static IStringMessage ReadMessage(IMessageHandler messageHandler)
         {
             return messageHandler.Read();
         }
 
-        private static IMessage ReadMessage(INamedPipe pipeClient)
+        private static IStringMessage ReadMessage(INamedPipe pipeClient)
         {
             return ReadMessage(pipeClient.MessageHandler);
         }

--- a/tests/CoreHook.Tests/NamedPipeTest.cs
+++ b/tests/CoreHook.Tests/NamedPipeTest.cs
@@ -43,7 +43,7 @@ namespace CoreHook.Tests
                 (message, channel) =>
                 {
                     Assert.Equal(message.ToString(), testMessage);
-                    channel.MessageHandler.Write(Message.FromString(testMessage));
+                    channel.MessageHandler.Write(StringMessage.FromString(testMessage));
                 }))
             using (var pipeClient = CreateClient(namedPipe))
             {
@@ -122,14 +122,14 @@ namespace CoreHook.Tests
         {
             if (pipeClient.Connect())
             {
-                return pipeClient.MessageHandler.TryWrite(Message.FromString(message));
+                return pipeClient.MessageHandler.TryWrite(StringMessage.FromString(message));
             }
             return false;
         }
 
         private static bool SendPipeMessage(IMessageHandler messageHandler, string message)
         {
-            return SendPipeMessage(messageHandler, Message.FromString(message));
+            return SendPipeMessage(messageHandler, StringMessage.FromString(message));
         }
 
         private static bool SendPipeMessage(IMessageHandler messageHandler, IMessage message)


### PR DESCRIPTION
Add more specific names to the IPC message classes such as IMessage to IStringMessage instead of the generic message name.

* Rename interface IMessage to IStringMessage
* Rename class Messsage to StringMessage