### PR TITLE
Allow user to specify unmanaged callback object

### DIFF
--- a/src/CoreHook/HookFactory.cs
+++ b/src/CoreHook/HookFactory.cs
@@ -12,7 +12,7 @@ namespace CoreHook
         /// </summary>
         /// <param name="targetFunction">The target function address that will be detoured.</param>
         /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
-        /// <param name="callback">A context object that can be accessed as <see cref="HookRuntimeInfo.Callback"/>.</param>
+        /// <param name="callback">A context object that can be accessed as <see cref="HookRuntimeInfo.Callback"/> by the detour function.</param>
         /// <returns>The handle to the function hook.</returns>
         public static IHook CreateHook(IntPtr targetFunction, Delegate detourFunction, object callback)
         {
@@ -20,39 +20,41 @@ namespace CoreHook
         }
 
         /// <summary>
-        /// Create an unmanaged hook.
-        /// </summary>
-        /// <param name="targetFunction">The target function address that will be detoured.</param>
-        /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
-        /// <returns>The handle to the function hook.</returns>
-        public static IHook CreateHook(IntPtr targetFunction, IntPtr detourFunction)
-        {
-            return LocalHook.CreateUnmanaged(targetFunction, detourFunction, IntPtr.Zero);
-        }
-
-        /// <summary>
-        /// Create an unmanaged hook.
-        /// </summary>
-        /// <typeparam name="T">The delegate type representing the detoured function signature.</typeparam>
-        /// <param name="targetFunction">The target function address that will be detoured.</param>
-        /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
-        /// <returns>The handle to the function hook.</returns>
-        public static IHook<T> CreateHook<T>(IntPtr targetFunction, IntPtr detourFunction) where T : class
-        {
-            return LocalHook<T>.CreateUnmanaged(targetFunction, detourFunction, IntPtr.Zero);
-        }
-
-        /// <summary>
         /// Create a managed hook.
         /// </summary>
-        /// <typeparam name="T">The delegate type representing the detoured function signature.</typeparam>
+        /// <typeparam name="TDelegate">The delegate type representing the detoured function signature.</typeparam>
         /// <param name="targetFunction">The target function address that will be detoured.</param>
         /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
-        /// <param name="callback">A context object that can be accessed as <see cref="HookRuntimeInfo.Callback"/>.</param>
+        /// <param name="callback">A context object that can be accessed as <see cref="HookRuntimeInfo.Callback"/> by the detour function.</param>
         /// <returns>The handle to the function hook.</returns>
-        public static IHook<T> CreateHook<T>(IntPtr targetFunction, T detourFunction, object callback = null) where T : class
+        public static IHook<TDelegate> CreateHook<TDelegate>(IntPtr targetFunction, TDelegate detourFunction, object callback = null) where TDelegate : class
         {
-            return LocalHook<T>.Create(targetFunction, detourFunction as Delegate, callback);
+            return LocalHook<TDelegate>.Create(targetFunction, detourFunction as Delegate, callback);
+        }
+
+        /// <summary>
+        /// Create an unmanaged hook.
+        /// </summary>
+        /// <param name="targetFunction">The target function address that will be detoured.</param>
+        /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
+        /// <param name="callback">An object that is associated with the hook and can be accessed by the detour function.</param>
+        /// <returns>The handle to the function hook.</returns>
+        public static IHook CreateHook(IntPtr targetFunction, IntPtr detourFunction, IntPtr? callback = null)
+        {
+            return LocalHook.CreateUnmanaged(targetFunction, detourFunction, callback ?? IntPtr.Zero);
+        }
+
+        /// <summary>
+        /// Create an unmanaged hook.
+        /// </summary>
+        /// <typeparam name="TDelegate">The delegate type representing the detoured function signature.</typeparam>
+        /// <param name="targetFunction">The target function address that will be detoured.</param>
+        /// <param name="detourFunction">The detour function that will be called instead of the function at <paramref name="targetFunction"/>.</param>
+        /// <param name="callback">An object that is associated with the hook and can be accessed by the detour function.</param>
+        /// <returns>The handle to the function hook.</returns>
+        public static IHook<TDelegate> CreateHook<TDelegate>(IntPtr targetFunction, IntPtr detourFunction, IntPtr? callback = null) where TDelegate : class
+        {
+            return LocalHook<TDelegate>.CreateUnmanaged(targetFunction, detourFunction, callback ?? IntPtr.Zero);
         }
     }
 }

--- a/src/CoreHook/PointerExtensions.cs
+++ b/src/CoreHook/PointerExtensions.cs
@@ -11,15 +11,14 @@ namespace CoreHook
         /// <summary>
         /// Convert a function address to a callable delegate method.
         /// </summary>
-        /// <typeparam name="T">The delegate type to cast the function to.</typeparam>
+        /// <typeparam name="TDelegate">The delegate type to cast the function to.</typeparam>
         /// <param name="function">A function address.</param>
         /// <returns>The callable delegate method at <paramref name="function"/>.</returns>
-        public static T ToFunction<T>(this IntPtr function) where T : class
+        public static TDelegate ToFunction<TDelegate>(this IntPtr function) where TDelegate : class
         {
-            // Verify that T is a Delegate type.
-            System.Diagnostics.Debug.Assert(typeof(Delegate).IsAssignableFrom(typeof(T)));
+            System.Diagnostics.Debug.Assert(typeof(Delegate).IsAssignableFrom(typeof(TDelegate)));
 
-            return Marshal.GetDelegateForFunctionPointer<T>(function);
+            return Marshal.GetDelegateForFunctionPointer<TDelegate>(function);
         }
     }
 }


### PR DESCRIPTION
Instead of defaulting to IntPtr.Zero, allow the user to set a callback object when creating unmanaged hooks since you could for example create an object with an unmanaged export and then use the address from that call to pass to the hook creation to be used inside the native detour function.